### PR TITLE
Miniupnpc

### DIFF
--- a/novacoin-qt.pro
+++ b/novacoin-qt.pro
@@ -75,7 +75,7 @@ contains(USE_UPNP, -) {
     count(USE_UPNP, 0) {
         USE_UPNP=1
     }
-    DEFINES += USE_UPNP=$$USE_UPNP STATICLIB
+    DEFINES += USE_UPNP=$$USE_UPNP STATICLIB MINIUPNP_STATICLIB
     INCLUDEPATH += $$MINIUPNPC_INCLUDE_PATH
     LIBS += $$join(MINIUPNPC_LIB_PATH,,-L,) -lminiupnpc
     win32:LIBS += -liphlpapi

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -39,7 +39,7 @@ ifneq (${USE_UPNP}, -)
  INCLUDEPATHS += -I"C:\miniupnpc-1.6-mgw"
  LIBPATHS += -L"C:\miniupnpc-1.6-mgw"
  LIBS += -l miniupnpc -l iphlpapi
- DEFS += -DSTATICLIB -DUSE_UPNP=$(USE_UPNP)
+ DEFS += -DSTATICLIB -DUSE_UPNP=$(USE_UPNP) -DMINIUPNP_STATICLIB
 endif
 
 ifneq (${USE_IPV6}, -)


### PR DESCRIPTION
Дополнительное определение препроцессора для miniupnpc 1.9
(http://miniupnp.free.fr/files/miniupnpc-1.9.20141027.tar.gz)
Совместимость с предыдущими miniupnpc сохранена.
Возможно такое же определение нужно и для сборки на Linux и на Mac, у
меня нет возможности проверить сборку. Если нужно, то измените так же и
makefiles для этих платформ.
