### PR TITLE
bad define ssize_t

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -13,7 +13,8 @@
 #endif
 
 #ifdef _MSC_VER
-#define ssize_t size_t
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
 #endif
 
 #include "strlcpy.h"


### PR DESCRIPTION
[quote=0xDEADFACE]
Есть сомнения насчет того, что можно использовать такой дефайн для ssize_t. Ведь ssize_t знаковый, а size_t нет. Функция может возвращать индекс при успехе или отрицательное значение в случае ошибки.

Для MSVC лучше делать так:
# ifdef _MSC_VER
# include <BaseTsd.h>

typedef SSIZE_T ssize_t;
# endif

SSIZE_T определен в BaseTsd.h файле WIndows SDK.

Надо наверно поправить и посмотреть как соберется.
[/quote]
Да, с помощью 
# include <BaseTsd.h>

typedef SSIZE_T ssize_t;
всё собирается. 
Вот я ещё в одном месте раньше дефайнил ssize_t в size_t
