### PR TITLE
более частое обновление статистики

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -420,7 +420,10 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
 
         setNumBlocks(clientModel->getNumBlocks(), clientModel->getNumBlocksOfPeers());
         connect(clientModel, SIGNAL(numBlocksChanged(int,int)), this, SLOT(setNumBlocks(int,int)));
-        connect(clientModel, SIGNAL(numBlocksChanged(int,int)), this, SLOT(updateMining()));
+
+        QTimer *timer = new QTimer(this);
+        connect(timer, SIGNAL(timeout()), this, SLOT(updateMining()));
+        timer->start(10*1000); //10 seconds
 
         // Report errors from network/worker thread
         connect(clientModel, SIGNAL(error(QString,QString,bool)), this, SLOT(error(QString,QString,bool)));

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1630,8 +1630,7 @@ void CWallet::GetStakeStats(float &nKernelsRate, float &nCoinDaysRate)
 {
     static uint64 nLastKernels = 0, nLastCoinDays = 0;
     static float nLastKernelsRate = 0, nLastCoinDaysRate = 0;
-    static unsigned int nLastTime = GetTime();
-
+    static int64 nLastTime = GetTime();
 
     if (nKernelsTried < nLastKernels)
     {
@@ -1641,8 +1640,9 @@ void CWallet::GetStakeStats(float &nKernelsRate, float &nCoinDaysRate)
         nLastTime = GetTime();
     }
 
-    unsigned int nInterval = GetTime() - nLastTime;
-    if (nKernelsTried > 1000 && nInterval > 5)
+    int64 nInterval = GetTime() - nLastTime;
+    //if (nKernelsTried > 1000 && nInterval > 5)
+    if (nInterval > 10)
     {
         nKernelsRate = nLastKernelsRate = ( nKernelsTried - nLastKernels ) / (float) nInterval;
         nCoinDaysRate = nLastCoinDaysRate = ( nCoinDaysTried - nLastCoinDays ) / (float) nInterval;


### PR DESCRIPTION
Изменение всплывающей подсказки у значка PoS майнинга каждые 10 секунд, вместо каждого нового блока + убрано ограничение на расчёт 1000 хешей перед пересчётом статистики.
