### PR TITLE
senderAddress

### DIFF
--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -9,6 +9,9 @@
 #include "ui_interface.h"
 #include "base58.h"
 
+#include <vector>
+#include <algorithm>
+
 QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)
 {
     if (!wtx.IsFinal())
@@ -84,6 +87,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx)
                         {
                             if (wallet->mapAddressBook.count(address))
                             {
+                                std::vector<CTxDestination> addedAddresses;
                                 for (unsigned int i = 0; i < wtx.vin.size(); i++)
                                 {
                                     uint256 hash;
@@ -101,8 +105,10 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx)
                                     {
                                         strHTML += "<b>" + tr("From") + ":</b> " + tr("unknown") + "<br>";
                                     }
-                                    else
+                                    else if(std::find(addedAddresses.begin(), addedAddresses.end(), senderAddress) 
+                                            == addedAddresses.end() )
                                     {
+                                        addedAddresses.push_back(senderAddress);
                                         strHTML += "<b>" + tr("From") + ":</b> ";
                                         strHTML += GUIUtil::HtmlEscape(CBitcoinAddress(senderAddress).ToString());
                                         if(wallet->mapAddressBook.find(senderAddress) !=  wallet->mapAddressBook.end())


### PR DESCRIPTION
**Не для merge! Нужны доработки**
В подробностях транзакции показываются адреса от кого получена транзакция. 
Было:
![before](http://i57.tinypic.com/fe4d8i.jpg)
Стало:
![now](http://i62.tinypic.com/2ezgx75.jpg)

Нерешённые вопросы:
1. Может быть, если у транзакции много входов, то показывать не все адреса? Если да, то какое число считать "много входов"?
2. Возможно стоит убрать повторяющиеся адреса? Если да, то убирать ли повторяющиеся "неизвестно" ?(Например, у транзакции 3 входа, удалось получить из pubkey только 1 адрес, стоит ли писать 2 раза "неизвестно"?)
3. В качестве адреса показывать алиас из адресной книги, если такой адрес в ней есть.
