### PR TITLE
fix_MSVC

### DIFF
--- a/src/stun.cpp
+++ b/src/stun.cpp
@@ -41,10 +41,8 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #endif
-#ifndef _MSC_VER
+#ifndef WIN32
 #include <unistd.h>
-#else
-#include <io.h>
 #endif
 #include <time.h>
 #include <errno.h>
@@ -509,10 +507,10 @@ static int StunRequest(const char *host, uint16_t port, struct sockaddr_in *mapp
     int rc = -3;
     if(bind(sock, (struct sockaddr*)&client, sizeof(client)) >= 0)
         rc = StunRequest2(sock, &server, mapped);
-#ifndef _MSC_VER
+#ifndef WIN32
     close(sock);
 #else
-    _close(sock);
+    closesocket(sock);
 #endif
     return rc;
 } // StunRequest


### PR DESCRIPTION
При адаптации STUN модуля к MSVC(https://github.com/novacoin-project/novacoin/commit/196cd7a443bc09ac1485cce0e82e472a46a78152) я допустил баг. Использовал функцию _close() для закрытия сокета. А её можно использовать только для закрытия файлов . Сейчас должно быть
верно.
closesocket() нужно использовать и для MinGW, потому что в unistd.h написано только  #include io.h  и несколько #define, то есть выполняется та же самая функция close() для закрытия файлов.

Информация по теме:
https://stackoverflow.com/questions/20847057/can-you-close-read-and-write-a-socket-on-windows
