### PR TITLE
fix typo

### DIFF
--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -1722,7 +1722,7 @@ This label turns red, if the priority is smaller than &quot;medium&quot;.
     <message>
         <location line="-29"/>
         <source>Total of coins that was staked, and do not yet count toward the current balance</source>
-        <translation>Общая сумма всех монет, используемых для Proof-of-Stake, и не учитывающихся на балансе</translation>
+        <translation>Общая сумма всех монет, использованных для Proof-of-Stake, и не учитывающихся на балансе</translation>
     </message>
     <message>
         <location line="+75"/>


### PR DESCRIPTION
**Echoes**:

> > На btcsec юзер прислал скрин
> > ![картинка](https://forum.btcsec.com/uploads/monthly_12_2014/post-2891-0-43883200-1418039426.jpg)
> > Он думает, что у него в pos-майнинге участвуют только 13.16762 монет, в заблуждение вводит тултип, надо написать не используемых, а использованных для Proof-of-stake.
