### PR TITLE
обновление библиотек

### DIFF
--- a/doc/building novacoind and novacoinqt under Windows with MinGW.txt
+++ b/doc/building novacoind and novacoinqt under Windows with MinGW.txt
@@ -21,7 +21,7 @@ msys-libtool-bin
 -нажмите Installation, Apply Changes, Apply. После завершения установки нажмите Close и закройте MinGW Installation Manager.
 
 1.3 Установка MinGW-builds project toolchain:
-Скачайте http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/4.9.1/threads-posix/dwarf/i686-4.9.1-release-posix-dwarf-rt_v3-rev1.7z/download
+Скачайте http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/4.9.2/threads-posix/dwarf/i686-4.9.2-release-posix-dwarf-rt_v3-rev0.7z/download
 и распакуйте на C:\
 
 1.4 Добавьте в переменную PATH путь C:\mingw32\bin;
@@ -33,7 +33,7 @@ https://www.java.com/ru/download/help/path.xml
 1)C:\MinGW\bin должен содержать только файл mingw-get.exe
 2)Откройте Командную строку (Нажмите кнопку Windows + R одновременно. Откроется окно "Выполнить", в поле открыть наберите cmd. Нажмите Ok). Наберите gcc -v. В командной строке выведется текст. В конце текста должно быть написано:
 Thread model: posix
-gcc version 4.9.1 (i686-posix-dwarf-rev1, Built by MinGW-W64 project)
+gcc version 4.9.2 (i686-posix-dwarf-rev0, Built by MinGW-W64 project)
 
 2. Построение зависимостей.
 В инструкции все зависимости сохраняются в папку c:\deps
@@ -50,38 +50,38 @@ Configure no-shared no-dso mingw
 make
 
 2.2 Berkeley DB
--Скачайте http://download.oracle.com/berkeley-db/db-6.0.20.tar.gz
+-Скачайте http://download.oracle.com/berkeley-db/db-6.1.19.tar.gz
 -Из MinGw shell выполните следующий код:
 
 cd /c/deps/
-tar xvfz db-6.0.20.tar.gz
-cd db-6.0.20/build_unix
+tar xvfz db-6.1.19.tar.gz
+cd db-6.1.19/build_unix
 ../dist/configure --enable-mingw --enable-cxx --disable-shared --disable-replication
 make
 
 2.3 Boost
--Скачайте http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.7z/download
--Распакуйте boost_1_55_0.7z в папку C:\deps
+-Скачайте http://sourceforge.net/projects/boost/files/boost/1.57.0/boost_1_57_0.7z/download
+-Распакуйте boost_1_57_0.7z в папку C:\deps
 -Откройте командную строку Windows, и выполните следующий код:
 
-cd C:\deps\boost_1_55_0\
+cd C:\deps\boost_1_57_0\
 bootstrap.bat mingw
 b2 --build-type=complete --with-chrono --with-filesystem --with-program_options --with-system --with-thread toolset=gcc variant=release link=static threading=multi runtime-link=static stage
 
 2.4 Miniupnpc
--Скачайте http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.8.20131209.tar.gz
--Распакуйте miniupnpc-1.8.20131209.tar.gz с помощью 7z. (Распаковать нужно 2 раза, нажмите на файле miniupnpc-1.8.20131209.tar.gz левой кнопкой мыши и выберите 7-Zip, затем Распаковать здесь. Появится файл miniupnpc-1.8.20131209.tar. С ним аналогично, левая кнопка мыши -> 7-Zip -> Распаковать здесь. Появится папка miniupnpc-1.8.20131209. Переименуйте её в miniupnpc.
+-Скачайте http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.9.20141128.tar.gz
+-Распакуйте miniupnpc-1.9.20141128.tar.gz с помощью 7z. (Распаковать нужно 2 раза, нажмите на файле miniupnpc-1.9.20141128.tar.gz левой кнопкой мыши и выберите 7-Zip, затем Распаковать здесь. Появится файл miniupnpc-1.9.20141128.tar. С ним аналогично, левая кнопка мыши -> 7-Zip -> Распаковать здесь. Появится папка miniupnpc-1.9.20141128. Переименуйте её в miniupnpc.
 -Откройте командную строку Windows, и выполните следующий код:
 
 cd C:\deps\miniupnpc
 mingw32-make -f Makefile.mingw init upnpc-static
 
 2.5 qrencode
--Скачайте http://prdownloads.sourceforge.net/libpng/libpng-1.6.12.tar.gz?download
+-Скачайте http://download.sourceforge.net/libpng/libpng-1.6.15.tar.gz?download
 -Распакуйте
 -Откройте MinGw shell (C:\MinGW\msys\1.0\msys.bat) и выполните следующий код:
 
-cd /c/deps/libpng-1.6.12
+cd /c/deps/libpng-1.6.15
 configure --disable-shared
 make
 cp .libs/libpng16.a .libs/libpng.a
@@ -92,9 +92,9 @@ cp .libs/libpng16.a .libs/libpng.a
 
 cd /c/deps/qrencode-3.4.4
 
-LIBS="../libpng-1.6.12/.libs/libpng.a ../../mingw32/i686-w64-mingw32/lib/libz.a" \
-png_CFLAGS="-I../libpng-1.6.12" \
-png_LIBS="-L../libpng-1.6.12/.libs" \
+LIBS="../libpng-1.6.15/.libs/libpng.a ../../mingw32/i686-w64-mingw32/lib/libz.a" \
+png_CFLAGS="-I../libpng-1.6.15" \
+png_LIBS="-L../libpng-1.6.15/.libs" \
 configure --enable-static --disable-shared --without-tools
 
 make
@@ -106,30 +106,30 @@ mingw32-make
 используйте
 mingw32-make -j n , где вместо n количество ядер вашего процессора
 Qt 5:
--Скачайте http://download.qt-project.org/official_releases/qt/5.3/5.3.2/submodules/qtbase-opensource-src-5.3.2.7z
-http://download.qt-project.org/official_releases/qt/5.3/5.3.2/submodules/qttools-opensource-src-5.3.2.7z
-http://download.qt-project.org/official_releases/qt/5.3/5.3.2/submodules/qttranslations-opensource-src-5.3.2.7z
+-Скачайте http://download.qt-project.org/official_releases/qt/5.4/5.4.0/submodules/qtbase-opensource-src-5.4.0.7z
+http://download.qt-project.org/official_releases/qt/5.4/5.4.0/submodules/qttools-opensource-src-5.4.0.7z
+http://download.qt-project.org/official_releases/qt/5.4/5.4.0/submodules/qttranslations-opensource-src-5.4.0.7z
 
 -Распакуйте в C:\Qt
--Переименуйте папку qtbase-opensource-src-5.3.2 в 5.3.2
+-Переименуйте папку qtbase-opensource-src-5.4.0 в 5.4.0
 -Откройте командную строку Windows и выполните следующий код:
 
-set INCLUDE=C:\deps\libpng-1.6.12;C:\deps\openssl-1.0.1j\include
-set LIB=C:\deps\libpng-1.6.12\.libs;C:\deps\openssl-1.0.1j
+set INCLUDE=C:\deps\libpng-1.6.15;C:\deps\openssl-1.0.1j\include
+set LIB=C:\deps\libpng-1.6.15\.libs;C:\deps\openssl-1.0.1j
 
-cd C:\Qt\5.3.2
+cd C:\Qt\5.4.0
 
-configure.bat -release -opensource -confirm-license -static -make libs -no-sql-sqlite -no-opengl -system-zlib -qt-pcre -no-icu -no-gif -system-libpng -no-libjpeg -no-freetype -no-angle -no-vcproj -openssl -no-dbus -no-audio-backend -no-wmf-backend -no-qml-debug
+configure.bat -release -opensource -confirm-license -static -make libs -no-sql-sqlite -no-opengl -system-zlib -qt-pcre -no-icu -no-gif -system-libpng -no-libjpeg -no-freetype -no-angle -openssl -no-dbus -no-audio-backend -no-wmf-backend -no-qml-debug
 
 mingw32-make
 
-set PATH=%PATH%;C:\Qt\5.3.2\bin
+set PATH=%PATH%;C:\Qt\5.4.0\bin
 
-cd C:\Qt\qttools-opensource-src-5.3.2
+cd C:\Qt\qttools-opensource-src-5.4.0
 qmake qttools.pro
 mingw32-make
 
-cd C:\Qt\qttranslations-opensource-src-5.3.2
+cd C:\Qt\qttranslations-opensource-src-5.4.0
 qmake qttranslations.pro
 mingw32-make
 
@@ -159,22 +159,23 @@ mingw32-make
 -Перейдите в папку C:\MyProjects\novacoin-master\src
 -Откройте файл makefile.mingw в текстовом редакторе.(При написании инструкции использовался WordPad)
 -Поменяйте USE_UPNP:=0 на USE_UPNP:=1
+-Добавьте  строчку USE_ASM:=1
 -Поменяйте текущие INCLUDEPATHS, LIBPATHS, LIBS на:
 
-BOOST_SUFFIX?=-mgw49-mt-s-1_55
+BOOST_SUFFIX?=-mgw49-mt-s-1_57
 
 INCLUDEPATHS= \
  -I"$(CURDIR)" \
- -I"/c/deps/boost_1_55_0" \
+ -I"/c/deps/boost_1_57_0" \
  -I"/c/deps" \
- -I"/c/deps/db-6.0.20/build_unix" \
+ -I"/c/deps/db-6.1.19/build_unix" \
  -I"/c/deps/openssl-1.0.1j/include"
  
 LIBPATHS= \
  -L"$(CURDIR)/leveldb" \
- -L"/c/deps/boost_1_55_0/stage/lib" \
+ -L"/c/deps/boost_1_57_0/stage/lib" \
  -L"/c/deps/miniupnpc" \
- -L"/c/deps/db-6.0.20/build_unix" \
+ -L"/c/deps/db-6.1.19/build_unix" \
  -L"/c/deps/openssl-1.0.1j"
 
 LIBS= \
@@ -192,9 +193,11 @@ LIBS= \
 -Поменяйте LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat на 
 LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat -Wl,--large-address-aware -static
 
--Если вы хотите использовать LevelDB как базу блоков то добавьте в файл MinGW:
+-Если вы хотите использовать LevelDB как базу блоков то измените:
+USE_LEVELDB:=0 
+на
 USE_LEVELDB:=1
-(ниже USE_IPV6:=1)
+(выше USE_IPV6:=1)
 Так же измените 
 cd leveldb; make; cd ..
 на 
@@ -205,6 +208,8 @@ obj/txdb-leveldb.o: leveldb/libleveldb.lib
 на
 obj/txdb-leveldb.o: leveldb/libleveldb.a
 
+
+
 Если вы хотите использовать BerkeleyDB как базу блоков, то просто удалите строчку USE_LEVELDB:=1
 
 -Сохраните измененный файл makefile.mingw
@@ -214,6 +219,12 @@ obj/txdb-leveldb.o: leveldb/libleveldb.a
 cd /c/MyProjects/novacoin-master/src
 make -f makefile.mingw
 strip novacoind.exe
+
+Если у вас возникает ошибка "make: cc: Command not found", то поменяйте в файле makefile.mingw
+
+ $(CC) -c $(xCXXFLAGS) -MMD -o $@ $<
+на
+ gcc -c $(xCXXFLAGS) -MMD -o $@ $<
 
 Если всё сделано правильно, то файл novacoind.exe будет находится в папке C:\MyProjects\novacoin-master\src 
 
@@ -233,11 +244,11 @@ TARGET_OS=NATIVE_WINDOWS make libleveldb.a libmemenv.a
 #    BDB_LIB_PATH, OPENSSL_INCLUDE_PATH and OPENSSL_LIB_PATH respectively
 замените прописанные пути к зависимостям на
 
-BOOST_LIB_SUFFIX=-mgw49-mt-s-1_55
-BOOST_INCLUDE_PATH=C:/deps/boost_1_55_0
-BOOST_LIB_PATH=C:/deps/boost_1_55_0/stage/lib
-BDB_INCLUDE_PATH=C:/deps/db-6.0.20/build_unix
-BDB_LIB_PATH=C:/deps/db-6.0.20/build_unix
+BOOST_LIB_SUFFIX=-mgw49-mt-s-1_57
+BOOST_INCLUDE_PATH=C:/deps/boost_1_57_0
+BOOST_LIB_PATH=C:/deps/boost_1_57_0/stage/lib
+BDB_INCLUDE_PATH=C:/deps/db-6.1.19/build_unix
+BDB_LIB_PATH=C:/deps/db-6.1.19/build_unix
 OPENSSL_INCLUDE_PATH=C:/deps/openssl-1.0.1j/include
 OPENSSL_LIB_PATH=C:/deps/openssl-1.0.1j
 MINIUPNPC_INCLUDE_PATH=C:/deps/
@@ -266,31 +277,31 @@ win32:QMAKE_LFLAGS *= -Wl,--large-address-aware -static
 
 Qt5 + транзакционный индекс BDB 
 
-set PATH=%PATH%;C:\Qt\5.3.2\bin
+set PATH=%PATH%;C:\Qt\5.4.0\bin
 cd C:\MyProjects\novacoin-master
-qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" novacoin-qt.pro
+qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" "USE_ASM=1" novacoin-qt.pro
 mingw32-make -f Makefile.Release
 
 
 Qt5 + транзакционный индекс LevelDB
 
-set PATH=%PATH%;C:\Qt\5.3.2\bin
+set PATH=%PATH%;C:\Qt\5.4.0\bin
 cd C:\MyProjects\novacoin-master
-qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" "USE_LEVELDB=1" novacoin-qt.pro
+qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" "USE_LEVELDB=1" "USE_ASM=1" novacoin-qt.pro
 mingw32-make -f Makefile.Release
 
 Qt4 + транзакционный индекс BDB
 
 set PATH=%PATH%;C:\Qt\4.8.6\bin
 cd C:\MyProjects\novacoin-master
-qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" novacoin-qt.pro
+qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" "USE_ASM=1" novacoin-qt.pro
 mingw32-make -f Makefile.Release
 
 Qt4 + транзакционный индекс LevelDB
 
 set PATH=%PATH%;C:\Qt\4.8.6\bin
 cd C:\MyProjects\novacoin-master
-qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" "USE_LEVELDB=1" novacoin-qt.pro
+qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" "USE_LEVELDB=1" "USE_ASM=1" novacoin-qt.pro
 mingw32-make -f Makefile.Release
 
 
@@ -305,7 +316,7 @@ mingw32-make -f Makefile.Release
 1.2 Так же как 32 bit
 
 1.3 Установка MinGW-builds project toolchain:
-Скачайте http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/4.9.1/threads-posix/seh/x86_64-4.9.1-release-posix-seh-rt_v3-rev1.7z/download
+Скачайте http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/4.9.2/threads-posix/seh/x86_64-4.9.2-release-posix-seh-rt_v3-rev0.7z/download
 и распакуйте на C:\
 
 1.4 Удалите из переменной PATH путь C:\mingw32\bin; и добавьте в PATH путь C:\mingw64\bin;
@@ -314,7 +325,7 @@ mingw32-make -f Makefile.Release
 1)C:\MinGW\bin должен содержать только файл mingw-get.exe
 2)Откройте Командную строку (Нажмите кнопку Windows + R одновременно. Откроется окно "Выполнить", в поле открыть наберите cmd. Нажмите Ok). Наберите gcc -v. В командной строке выведется текст. В конце текста должно быть написано:
 Thread model: posix
-gcc version 4.9.1 (x86_64-posix-seh-rev1, Built by MinGW-W64 project)
+gcc version 4.9.2 (x86_64-posix-seh-rev0, Built by MinGW-W64 project)
 
 2. Построение зависимостей.
 В инструкции все зависимости сохраняются в папку c:\deps\x64
@@ -331,7 +342,7 @@ make
 
 2.2 Так же как 32 bit, только cd /c/deps/ меняется на cd /c/deps/x64/
 
-2.3 Так же как 32 bit, только распаковка в C:\deps\x64 и команда cd C:\deps\boost_1_55_0\ меняется на cd C:\deps\x64\boost_1_55_0\ 
+2.3 Так же как 32 bit, только распаковка в C:\deps\x64 и команда cd C:\deps\boost_1_57_0\ меняется на cd C:\deps\x64\boost_1_57_0\ 
 
 2.4 Так же как 32 bit, только распаковка в C:\deps\x64 и заменить cd C:\deps\miniupnpc на cd C:\deps\x64\miniupnpc
 
@@ -343,9 +354,9 @@ make
 
 cd /c/deps/x64/qrencode-3.4.4
 
-LIBS="../libpng-1.6.12/.libs/libpng.a ../../../mingw64/x86_64-w64-mingw32/lib/libz.a" \
-png_CFLAGS="-I../libpng-1.6.12" \
-png_LIBS="-L../libpng-1.6.12/.libs" \
+LIBS="../libpng-1.6.15/.libs/libpng.a ../../../mingw64/x86_64-w64-mingw32/lib/libz.a" \
+png_CFLAGS="-I../libpng-1.6.15" \
+png_LIBS="-L../libpng-1.6.15/.libs" \
 configure --enable-static --disable-shared --without-tools
 
 make
@@ -358,30 +369,31 @@ mingw32-make
 используйте
 mingw32-make -j n , где вместо n количество ядер вашего процессора
 Qt 5:
--Скачайте http://download.qt-project.org/official_releases/qt/5.3/5.3.2/submodules/qtbase-opensource-src-5.3.2.7z
-http://download.qt-project.org/official_releases/qt/5.3/5.3.2/submodules/qttools-opensource-src-5.3.2.7z
+-Скачайте http://download.qt-project.org/official_releases/qt/5.4/5.4.0/submodules/qtbase-opensource-src-5.4.0.7z
+http://download.qt-project.org/official_releases/qt/5.4/5.4.0/submodules/qttools-opensource-src-5.4.0.7z
+http://download.qt-project.org/official_releases/qt/5.4/5.4.0/submodules/qttranslations-opensource-src-5.4.0.7z
 -Распакуйте в C:\Qt
--Переименуйте папку qtbase-opensource-src-5.3.2 в 5.3.2-x64
--Переименуйте папку qttools-opensource-src-5.3.2 в qttools-opensource-src-5.3.2-x64
--Переименуйте папку qttranslations-opensource-src-5.3.2 в qttranslations-opensource-src-5.3.2-x64
+-Переименуйте папку qtbase-opensource-src-5.4.0 в 5.4.0-x64
+-Переименуйте папку qttools-opensource-src-5.4.0 в qttools-opensource-src-5.4.0-x64
+-Переименуйте папку qttranslations-opensource-src-5.4.0 в qttranslations-opensource-src-5.4.0-x64
 -Откройте командную строку Windows и выполните следующий код:
 
-set INCLUDE=C:\deps\x64\libpng-1.6.12;C:\deps\x64\openssl-1.0.1j\include
-set LIB=C:\deps\x64\libpng-1.6.12\.libs;C:\deps\x64\openssl-1.0.1j
+set INCLUDE=C:\deps\x64\libpng-1.6.15;C:\deps\x64\openssl-1.0.1j\include
+set LIB=C:\deps\x64\libpng-1.6.15\.libs;C:\deps\x64\openssl-1.0.1j
 
-cd C:\Qt\5.3.2-x64
+cd C:\Qt\5.4.0-x64
 
-configure.bat -release -opensource -confirm-license -static -make libs -no-sql-sqlite -no-opengl -system-zlib -qt-pcre -no-icu -no-gif -system-libpng -no-libjpeg -no-freetype -no-angle -no-vcproj -openssl -no-dbus -no-audio-backend -no-wmf-backend -no-qml-debug
+configure.bat -release -opensource -confirm-license -static -make libs -no-sql-sqlite -no-opengl -system-zlib -qt-pcre -no-icu -no-gif -system-libpng -no-libjpeg -no-freetype -no-angle -openssl -no-dbus -no-audio-backend -no-wmf-backend -no-qml-debug
 
 mingw32-make
 
-set PATH=%PATH%;C:\Qt\5.3.2-x64\bin
+set PATH=%PATH%;C:\Qt\5.4.0-x64\bin
 
-cd C:\Qt\qttools-opensource-src-5.3.2-x64
+cd C:\Qt\qttools-opensource-src-5.4.0-x64
 qmake qttools.pro
 mingw32-make
 
-cd C:\Qt\qttranslations-opensource-src-5.3.2-x64
+cd C:\Qt\qttranslations-opensource-src-5.4.0-x64
 qmake qttranslations.pro
 mingw32-make
 
@@ -441,7 +453,7 @@ TARGET_OS=NATIVE_WINDOWS make libleveldb.a libmemenv.a
 
 -Измените файл novacoin-qt.pro так же как в 32 bit
 -Откройте файл novacoin-qt.pro в текстовом редакторе и сохраните его как novacoin-qt64.pro
--Замените в INCLUDE и LIB путях текст C:/deps на текст C:/deps/x64 (то есть вместо C:/deps/boost_1_55_0 нужно C:/deps/x64/boost_1_55_0 и т.д.)
+-Замените в INCLUDE и LIB путях текст C:/deps на текст C:/deps/x64 (то есть вместо C:/deps/boost_1_57_0 нужно C:/deps/x64/boost_1_57_0 и т.д.)
 -Замените 
 win32:QMAKE_LFLAGS *= -Wl,--large-address-aware -static 
 на
@@ -451,31 +463,31 @@ win32:QMAKE_LFLAGS *= -Wl,-static
 
 Qt5 + транзакционный индекс BDB 
 
-set PATH=%PATH%;C:\Qt\5.3.2-x64\bin
+set PATH=%PATH%;C:\Qt\5.4.0-x64\bin
 cd C:\MyProjects\novacoin-master
-qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" novacoin-qt64.pro
+qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" "USE_ASM=1" novacoin-qt64.pro
 mingw32-make -f Makefile.Release
 
 
 Qt5 + транзакционный индекс LevelDB
 
-set PATH=%PATH%;C:\Qt\5.3.2-x64\bin
+set PATH=%PATH%;C:\Qt\5.4.0-x64\bin
 cd C:\MyProjects\novacoin-master
-qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" "USE_LEVELDB=1" novacoin-qt64.pro
+qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" "USE_LEVELDB=1" "USE_ASM=1" novacoin-qt64.pro
 mingw32-make -f Makefile.Release
 
 Qt4 + транзакционный индекс BDB
 
 set PATH=%PATH%;C:\Qt\4.8.6-x64\bin
 cd C:\MyProjects\novacoin-master
-qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" novacoin-qt64.pro
+qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" "USE_ASM=1" novacoin-qt64.pro
 mingw32-make -f Makefile.Release
 
 Qt4 + транзакционный индекс LevelDB
 
 set PATH=%PATH%;C:\Qt\4.8.6-x64\bin
 cd C:\MyProjects\novacoin-master
-qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" "USE_LEVELDB=1" novacoin-qt64.pro
+qmake "USE_QRCODE=1" "USE_UPNP=1" "USE_IPV6=1" "USE_LEVELDB=1" "USE_ASM=1" novacoin-qt64.pro
 mingw32-make -f Makefile.Release
 
 Если всё сделано правильно, то файл novacoin-qt.exe будет находится в папке C:\MyProjects\novacoin-master\release

--- a/src/net.h
+++ b/src/net.h
@@ -6,8 +6,10 @@
 #define BITCOIN_NET_H
 
 #include <deque>
+#ifndef Q_MOC_RUN
 #include <boost/array.hpp>
 #include <boost/foreach.hpp>
+#endif
 #include <openssl/rand.h>
 
 #ifndef WIN32

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -23,8 +23,10 @@
 #include <QDesktopServices>
 #include <QThread>
 
+#ifndef Q_MOC_RUN
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
+#endif
 
 #ifdef WIN32
 #ifdef _WIN32_WINNT

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -14,10 +14,12 @@
 #include <cstring>
 #include <cstdio>
 
+#ifndef Q_MOC_RUN
 #include <boost/type_traits/is_fundamental.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
 #include <boost/tuple/tuple_io.hpp>
+#endif
 
 #include "allocators.h"
 #include "version.h"

--- a/src/util.h
+++ b/src/util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2010 Satoshi Nakamoto
+﻿// Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -17,11 +17,14 @@
 #include <vector>
 #include <string>
 
+#ifndef Q_MOC_RUN
 #include <boost/thread.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/date_time/gregorian/gregorian_types.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
+#endif
+
 #include <stdarg.h>
 
 #include "netbase.h" // for AddTimeData


### PR DESCRIPTION
Обновил руководство **building novacoind and novacoinqt under Windows with MinGW.txt** в связи с выходом новых версий зависимостей:
- MinGW 4.9.2
- Qt 5.4.0 (также проверил с Qt 4.8.6 для сохранения совместимости)
- Berkley db-6.1.19
- miniupnpc-1.9.20141128
- libpng-1.6.15
- Boost 1.57

Получилось собрать, но нашёлся баг при сборке с Qt 4.8.6 и Boost 1.57
Не создавались .moc файлы.
Была ошибка **Parse error at "BOOST_JOIN"**
Поискал в гугле и нашёл решение тут https://bugreports.qt-project.org/browse/QTBUG-22829
(Решение: для moc не подключать boost библиотеки с помощью #ifndef Q_MOC_RUN )
