### PR TITLE
Возврат версии Berkley DB к 6.0.20

### DIFF
--- a/doc/building novacoind and novacoinqt under Windows with MinGW.txt
+++ b/doc/building novacoind and novacoinqt under Windows with MinGW.txt
@@ -50,12 +50,12 @@ Configure no-shared no-dso mingw
 make
 
 2.2 Berkeley DB
--Скачайте http://download.oracle.com/berkeley-db/db-6.1.19.tar.gz
+-Скачайте http://download.oracle.com/berkeley-db/db-6.0.20.tar.gz
 -Из MinGw shell выполните следующий код:
 
 cd /c/deps/
-tar xvfz db-6.1.19.tar.gz
-cd db-6.1.19/build_unix
+tar xvfz db-6.0.20.tar.gz
+cd db-6.0.20/build_unix
 ../dist/configure --enable-mingw --enable-cxx --disable-shared --disable-replication
 make
 
@@ -168,14 +168,14 @@ INCLUDEPATHS= \
  -I"$(CURDIR)" \
  -I"/c/deps/boost_1_57_0" \
  -I"/c/deps" \
- -I"/c/deps/db-6.1.19/build_unix" \
+ -I"/c/deps/db-6.0.20/build_unix" \
  -I"/c/deps/openssl-1.0.1j/include"
  
 LIBPATHS= \
  -L"$(CURDIR)/leveldb" \
  -L"/c/deps/boost_1_57_0/stage/lib" \
  -L"/c/deps/miniupnpc" \
- -L"/c/deps/db-6.1.19/build_unix" \
+ -L"/c/deps/db-6.0.20/build_unix" \
  -L"/c/deps/openssl-1.0.1j"
 
 LIBS= \
@@ -247,8 +247,8 @@ TARGET_OS=NATIVE_WINDOWS make libleveldb.a libmemenv.a
 BOOST_LIB_SUFFIX=-mgw49-mt-s-1_57
 BOOST_INCLUDE_PATH=C:/deps/boost_1_57_0
 BOOST_LIB_PATH=C:/deps/boost_1_57_0/stage/lib
-BDB_INCLUDE_PATH=C:/deps/db-6.1.19/build_unix
-BDB_LIB_PATH=C:/deps/db-6.1.19/build_unix
+BDB_INCLUDE_PATH=C:/deps/db-6.0.20/build_unix
+BDB_LIB_PATH=C:/deps/db-6.0.20/build_unix
 OPENSSL_INCLUDE_PATH=C:/deps/openssl-1.0.1j/include
 OPENSSL_LIB_PATH=C:/deps/openssl-1.0.1j
 MINIUPNPC_INCLUDE_PATH=C:/deps/


### PR DESCRIPTION
Кошелёк собранный с BerkleyDB 6.1.19 открывает базу и кошелёк созданный с помощью BerkleyDB 6.0.20, но кошелёк собранный с BerkleyDB 6.0.20 не открывает базу и кошелёк созданный с помощью BerkleyDB 6.1.19
Поэтому в целях обратной совместимости пока в инструкции по сборке пусть будет BerkleyDB 6.0.20
Если в будущем будет хардфорк, тогда можно обновить версию BerkleyDB до самой новой...
