### PR TITLE
fix MinGW build

### DIFF
--- a/novacoin-qt.pro
+++ b/novacoin-qt.pro
@@ -453,7 +453,7 @@ LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
 # -lgdi32 has to happen after -lcrypto (see  #681)
 windows:LIBS += -lws2_32 -lshlwapi -lmswsock -lole32 -loleaut32 -luuid -lgdi32
 LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX
-windows:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX -Wl,-Bstatic -lpthread -Wl,-Bdynamic
+windows:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX 
 
 contains(RELEASE, 1) {
     !windows:!macx {


### PR DESCRIPTION
Спасибо пользователю **Victor1739**, который заметил что MinGW сборки не работают.
Произошло неудачное стечение обстоятельств.
https://github.com/novacoin-project/novacoin/pull/86
1) **0xDEADFACE** добавил коммит https://github.com/novacoin-project/novacoin/commit/f67b5c1eb1c6e1660be48f1c93013219f17486a5
2) Примерно в это же время я синхронизировал fsb4000/novacoin до актуального novacoin-project/novacoin чтобы сделать https://github.com/novacoin-project/novacoin/pull/86 с переводом
3) **0xDEADFACE** откатывает этот коммит, когда видит что он ломает MinGW билд
4) я делаю https://github.com/novacoin-project/novacoin/pull/86
5) и этот коммит остаётся в моём пул реквесте
6) **CryptoManiaс** merged пул реквест, и коммит снова возвращается в novacoin-project
Хорошо что заметили до релиза 0.5.1 :)
Кстати, нужно проверить, может и MXE сборка починилась...