### PR TITLE
Rpc console

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -197,7 +197,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     // Double-clicking on a transaction on the transaction history page shows details
     connect(transactionView, SIGNAL(doubleClicked(QModelIndex)), transactionView, SLOT(showDetails()));
 
-    rpcConsole = new RPCConsole(this);
+    rpcConsole = new RPCConsole(0);
     connect(openRPCConsoleAction, SIGNAL(triggered()), rpcConsole, SLOT(show()));
 
     // Clicking on "Verify Message" in the address book sends you to the verify message tab
@@ -215,6 +215,8 @@ BitcoinGUI::~BitcoinGUI()
 #ifdef Q_OS_MAC
     delete appMenuBar;
 #endif
+
+    delete rpcConsole;
 }
 
 void BitcoinGUI::createActions()
@@ -809,6 +811,9 @@ void BitcoinGUI::closeEvent(QCloseEvent *event)
         }
 #endif
     }
+    // close rpcConsole in case it was open to make some space for the shutdown window
+    rpcConsole->close();
+
     QMainWindow::closeEvent(event);
 }
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -48,9 +48,18 @@ double ClientModel::getDifficulty(bool fProofofStake)
        return GetDifficulty(GetLastBlockIndex(pindexBest,false));
 }
 
-int ClientModel::getNumConnections() const
+int ClientModel::getNumConnections(uint8_t flags) const
 {
-    return vNodes.size();
+    LOCK(cs_vNodes);
+    if (flags == CONNECTIONS_ALL) // Shortcut if we want total
+        return vNodes.size();
+
+    int nNum = 0;
+    BOOST_FOREACH(CNode* pnode, vNodes)
+    if (flags & (pnode->fInbound ? CONNECTIONS_IN : CONNECTIONS_OUT))
+        nNum++;
+
+    return nNum;
 }
 
 int ClientModel::getNumBlocks() const

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -3,6 +3,8 @@
 
 #include <QObject>
 
+#include <stdint.h>
+
 class OptionsModel;
 class AddressTableModel;
 class TransactionTableModel;
@@ -12,6 +14,13 @@ QT_BEGIN_NAMESPACE
 class QDateTime;
 class QTimer;
 QT_END_NAMESPACE
+
+enum NumConnections {
+    CONNECTIONS_NONE = 0,
+    CONNECTIONS_IN = (1U << 0),
+    CONNECTIONS_OUT = (1U << 1),
+    CONNECTIONS_ALL = (CONNECTIONS_IN | CONNECTIONS_OUT),
+};
 
 /** Model for Bitcoin network client. */
 class ClientModel : public QObject
@@ -26,7 +35,8 @@ public:
     double getPoSKernelPS();
     double getDifficulty(bool fProofofStake);
 
-    int getNumConnections() const;
+    //! Return number of connections, default is in- and outbound (total)
+    int getNumConnections(uint8_t flags = CONNECTIONS_ALL) const;
     int getNumBlocks() const;
     int getNumBlocksAtStartup();
 

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>RPCConsole</class>
- <widget class="QDialog" name="RPCConsole">
+ <widget class="QWidget" name="RPCConsole">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -113,13 +113,39 @@
         </widget>
        </item>
        <item row="4" column="0">
+         <widget class="QLabel" name="label_berkeleyDBVersion">
+           <property name="text">
+             <string>Using BerkeleyDB version</string>
+           </property>
+           <property name="indent">
+             <number>10</number>
+           </property>
+         </widget>
+       </item>
+       <item row="4" column="1">
+         <widget class="QLabel" name="berkeleyDBVersion">
+           <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+           </property>
+           <property name="text">
+             <string>N/A</string>
+           </property>
+           <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+           </property>
+           <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+           </property>
+         </widget>
+       </item>
+       <item row="5" column="0">
         <widget class="QLabel" name="label_12">
          <property name="text">
           <string>Build date</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <widget class="QLabel" name="buildDate">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -135,14 +161,14 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="label_13">
          <property name="text">
           <string>Startup time</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <widget class="QLabel" name="startupTime">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -158,7 +184,7 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="label_11">
          <property name="font">
           <font>
@@ -171,14 +197,14 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>Number of connections</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="8" column="1">
         <widget class="QLabel" name="numberOfConnections">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -194,14 +220,14 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>On testnet</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <widget class="QCheckBox" name="isTestNet">
          <property name="enabled">
           <bool>false</bool>
@@ -211,7 +237,7 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="label_10">
          <property name="font">
           <font>
@@ -224,14 +250,14 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="11" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
           <string>Current number of blocks</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <widget class="QLabel" name="numberOfBlocks">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -247,14 +273,14 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="0">
+       <item row="12" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Estimated total blocks</string>
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <widget class="QLabel" name="totalBlocks">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -270,14 +296,14 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
+       <item row="13" column="0">
         <widget class="QLabel" name="label_2">
          <property name="text">
           <string>Last block time</string>
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <widget class="QLabel" name="lastBlockTime">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -293,7 +319,7 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
+       <item row="14" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -306,7 +332,7 @@
          </property>
         </spacer>
        </item>
-       <item row="14" column="0">
+       <item row="15" column="0">
         <widget class="QLabel" name="labelDebugLogfile">
          <property name="font">
           <font>
@@ -319,7 +345,7 @@
          </property>
         </widget>
        </item>
-       <item row="15" column="0">
+       <item row="16" column="0">
         <widget class="QPushButton" name="openDebugLogfileButton">
          <property name="toolTip">
           <string>Open the NovaCoin debug log file from the current data directory. This can take a few seconds for large log files.</string>
@@ -332,7 +358,7 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="0">
+       <item row="17" column="0">
         <widget class="QLabel" name="labelCLOptions">
          <property name="font">
           <font>
@@ -345,7 +371,7 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="0">
+       <item row="18" column="0">
         <widget class="QPushButton" name="showCLOptionsButton">
          <property name="toolTip">
           <string>Show the NovaCoin-Qt help message to get a list with possible NovaCoin command-line options.</string>
@@ -358,7 +384,7 @@
          </property>
         </widget>
        </item>
-       <item row="18" column="0">
+       <item row="19" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -2079,6 +2079,11 @@ This label turns red, if the priority is smaller than &quot;medium&quot;.
 <context>
     <name>RPCConsole</name>
     <message>
+      <location filename="../forms/rpcconsole.ui" line="118"/>
+      <source>Using BerkeleyDB version</source>
+      <translation>Используется версия BerkeleyDB</translation>
+    </message>
+    <message>
         <location filename="../forms/rpcconsole.ui" line="+582"/>
         <source>Received:</source>
         <translation>Получено:</translation>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -2079,6 +2079,16 @@ This label turns red, if the priority is smaller than &quot;medium&quot;.
 <context>
     <name>RPCConsole</name>
     <message>
+      <location filename="../rpcconsole.cpp" line="352"/>
+      <source>Inbound:</source>
+      <translation>Входящие:</translation>
+    </message>
+    <message>
+      <location filename="../rpcconsole.cpp" line="353"/>
+      <source>Outbound:</source>
+      <translation>Исходящие:</translation>
+    </message>
+    <message>
       <location filename="../forms/rpcconsole.ui" line="118"/>
       <source>Using BerkeleyDB version</source>
       <translation>Используется версия BerkeleyDB</translation>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -15,6 +15,7 @@
 #include <QScrollBar>
 
 #include <openssl/crypto.h>
+#include <db_cxx.h>
 
 // TODO: make it possible to filter out categories (esp debug messages when implemented)
 // TODO: receive errors and debug messages through ClientModel
@@ -207,8 +208,9 @@ RPCConsole::RPCConsole(QWidget *parent) :
     connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
     connect(ui->btnClearTrafficGraph, SIGNAL(clicked()), ui->trafficGraph, SLOT(clear()));
 
-    // set OpenSSL version label
+    // set library version labels
     ui->openSSLVersion->setText(SSLeay_version(SSLEAY_VERSION));
+    ui->berkeleyDBVersion->setText(DbEnv::version(0, 0, 0));
 
     startExecutor();
     setTrafficGraphRange(INITIAL_TRAFFIC_GRAPH_MINS);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -345,7 +345,14 @@ void RPCConsole::message(int category, const QString &message, bool html)
 
 void RPCConsole::setNumConnections(int count)
 {
-    ui->numberOfConnections->setText(QString::number(count));
+    if (!clientModel)
+        return;
+
+    QString connections = QString::number(count) + " (";
+    connections += tr("Inbound:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_IN)) + " / ";
+    connections += tr("Outbound:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_OUT)) + ")";
+
+    ui->numberOfConnections->setText(connections);
 }
 
 void RPCConsole::setNumBlocks(int count, int countOfPeers)

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -369,8 +369,8 @@ void RPCConsole::on_lineEdit_returnPressed()
     {
         message(CMD_REQUEST, cmd);
         emit cmdRequest(cmd);
-        // Truncate history from current position
-        history.erase(history.begin() + historyPtr, history.end());
+        // Remove command, if already in history
+        history.removeOne(cmd);
         // Append command to history
         history.append(cmd);
         // Enforce maximum history size

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -189,7 +189,7 @@ void RPCExecutor::request(const QString &command)
 }
 
 RPCConsole::RPCConsole(QWidget *parent) :
-    QDialog(parent, DIALOGWINDOWHINTS),
+    QWidget(parent),
     ui(new Ui::RPCConsole),
     historyPtr(0)
 {
@@ -255,7 +255,7 @@ bool RPCConsole::eventFilter(QObject* obj, QEvent *event)
             }
         }
     }
-    return QDialog::eventFilter(obj, event);
+    return QWidget::eventFilter(obj, event);
 }
 
 void RPCConsole::setClientModel(ClientModel *model)
@@ -493,4 +493,12 @@ void RPCConsole::hideEvent(QHideEvent *event)
 
     if (!clientModel)
         return;
+}
+
+void RPCConsole::keyPressEvent(QKeyEvent *event)
+{
+    if(windowType() != Qt::Widget && event->key() == Qt::Key_Escape)
+    {
+        close();
+    }
 }

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -1,7 +1,7 @@
 #ifndef RPCCONSOLE_H
 #define RPCCONSOLE_H
 
-#include <QDialog>
+#include <QWidget>
 
 namespace Ui {
     class RPCConsole;
@@ -9,7 +9,7 @@ namespace Ui {
 class ClientModel;
 
 /** Local Bitcoin RPC console. */
-class RPCConsole: public QDialog
+class RPCConsole: public QWidget
 {
     Q_OBJECT
 
@@ -29,6 +29,7 @@ public:
 
 protected:
     virtual bool eventFilter(QObject* obj, QEvent *event);
+    void keyPressEvent(QKeyEvent *);
 
 private slots:
     void on_lineEdit_returnPressed();


### PR DESCRIPTION
Перенёс несколько коммитов из Bitcoin связанных с RPC console
1)https://github.com/bitcoin/bitcoin/commit/4a8fc152a957e54e6dd910de4382678f5c405198
RPC console становится Widget вместо Dialog. То есть теперь окошко RPC консоли не будет сворачиваться, если нажать свернуть у кошелька. С другой стороны RPC консоль теперь не всегда поверх кошелька, то есть может скрываться за кошельком. Иногда это неудобно...
2)https://github.com/bitcoin/bitcoin/commit/fe6bff2eaec35c3dc292af883a6e82397e440c22 
Показывать версию BerkeleyDB в RPC консоли
3)https://github.com/bitcoin/bitcoin/pull/4300
Не сохранять повторные команды в истории RPC консоли
4)https://github.com/bitcoin/bitcoin/pull/3685
Показывать не просто число подключений кошелька, а число входящих/исходящих подключений.
Вот так примерно стала выглядить RPC консоль:
![rpcconcolse](http://i62.tinypic.com/dop554.jpg)