### PR TITLE
fix "List iterator not dereferencable" and "List iterator not incrementable"

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1469,7 +1469,7 @@ void ThreadOpenAddedConnections2(void* parg)
             LOCK(cs_vNodes);
             BOOST_FOREACH(CNode* pnode, vNodes)
                 for (list<vector<CService> >::iterator it = lservAddressesToAdd.begin(); it != lservAddressesToAdd.end(); it++)
-                 {
+                {
                     BOOST_FOREACH(CService& addrNode, *(it))
                         if (pnode->addr == addrNode)
                         {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1469,13 +1469,18 @@ void ThreadOpenAddedConnections2(void* parg)
             LOCK(cs_vNodes);
             BOOST_FOREACH(CNode* pnode, vNodes)
                 for (list<vector<CService> >::iterator it = lservAddressesToAdd.begin(); it != lservAddressesToAdd.end(); it++)
+                 {
                     BOOST_FOREACH(CService& addrNode, *(it))
                         if (pnode->addr == addrNode)
                         {
                             it = lservAddressesToAdd.erase(it);
-                            it--;
+                            if(it != lservAddressesToAdd.begin())
+                                it--;
                             break;
                         }
+                    if (it == lservAddressesToAdd.end())
+                        break;
+                }
         }
         BOOST_FOREACH(vector<CService>& vserv, lservAddressesToAdd)
         {


### PR DESCRIPTION
**lservAddressesToAdd.erase(it)** возвращает итератор, который указывает на первый элемент, оставшиеся за всеми удаленными элементами, или указывает на конец списка, если такой элемент не существует.  Если список пуст, то **lservAddressesToAdd::end** == **lservAddressesToAdd::begin**. Если **it == lservAddressesToAdd::begin**, то **it--;** вызовет ошибку времени исполнения: "List iterator not dereferencable" 
Если **it == lservAddressesToAdd::end**, то **it++**(в цикле for) вызовет ошибку времени исполнения:"List iterator not incrementable"
Такое поведение у Microsoft Visual C++ в 2012 студии. У gcc скорее всего было всё нормально, раз баг не был замечен ранее...