### PR TITLE
использовать актуальное значение "монетодней" для сортировки  во вкладке POS

### DIFF
--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -352,7 +352,7 @@ QVariant MintingTableModel::data(const QModelIndex &index, int role) const
         case Age:
             return static_cast<qlonglong>(rec->getAge());
         case CoinDay:
-            return static_cast<qlonglong>(rec->coinAge);
+            return static_cast<qlonglong>(rec->getCoinDay());
         case Balance:
             return static_cast<qlonglong>(rec->nValue);
         case MintProbability:


### PR DESCRIPTION
(Qt::EditRole выбран для сортировки в файле mintingview.cpp , в функции void MintingView::setModel(WalletModel *model) , в строке mintingProxyModel->setSortRole(Qt::EditRole); )

Должно решить эту проблему: https://github.com/novacoin-project/novacoin/issues/91