### PR TITLE
Android, AboutDialog, Copyright

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,8 @@
-Copyright (c) 2013 NovaCoin Developers
-Copyright (c) 2011-2012 PPCoin Developers
-Copyright (c) 2009-2012 Bitcoin Developers
+﻿Copyright © 2009-2015 The Bitcoin developers
+Copyright © 2011-2012 The PPCoin Developers
+Copyright © 2014 The Peerunity Developers
+Copyright © 2014 The EmerCoin Developers
+Copyright © 2012-2015 The NovaCoin developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/doc/building novacoin-qt for android under Windows.txt
+++ b/doc/building novacoin-qt for android under Windows.txt
@@ -145,25 +145,6 @@ TARGET_OS=OS_ANDROID_CROSSCOMPILE make libleveldb.a libmemenv.a
 3. Компиляция
 3.1 Собираем Novacoin QT
 
-Откройте файл src\compat.h
-Измените #include <sys/fcntl.h> на #include <fcntl.h>
-
-Откройте файл src\util.cpp
-Закоментируйте строки с 59 по 61
-//#ifndef WIN32
-//#include <execinfo.h>
-//#endif
-Закоментируйте строки с 1062 по 1067
-//#ifndef WIN32
-//        void* pszBuffer[32];
-//        size_t size;
-//        size = backtrace(pszBuffer, 32);
-//        backtrace_symbols_fd(pszBuffer, size, fileno(fileout));
-//#endif
-
-Откройте файл src\netbase.cpp
-Измените #include <sys/fcntl.h> на #include <fcntl.h>
-
 Откройте файл novacoin-qt.pro
 Вместо 
 

--- a/src/compat.h
+++ b/src/compat.h
@@ -23,7 +23,11 @@
 #else
 #include <sys/types.h>
 #include <sys/socket.h>
+#ifdef ANDROID
+#include <fcntl.h>
+#else
 #include <sys/fcntl.h>
+#endif
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <net/if.h>

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -9,7 +9,11 @@
 #include "hash.h"
 
 #ifndef WIN32
+#ifdef ANDROID
+#include <fcntl.h>
+#else
 #include <sys/fcntl.h>
+#endif
 #endif
 
 #ifdef _MSC_VER

--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -7,8 +7,10 @@
 
 #include "version.h"
 
+#include <QKeyEvent>
+
 AboutDialog::AboutDialog(QWidget *parent) :
-    QDialog(parent, DIALOGWINDOWHINTS),
+    QWidget(parent, DIALOGWINDOWHINTS),
     ui(new Ui::AboutDialog)
 {
     ui->setupUi(this);
@@ -30,4 +32,19 @@ AboutDialog::~AboutDialog()
 void AboutDialog::on_buttonBox_accepted()
 {
     close();
+}
+
+void AboutDialog::keyPressEvent(QKeyEvent *event)
+{
+#ifdef ANDROID
+    if(event->key() == Qt::Key_Back)
+    {
+        close();
+    }
+#else
+    if(event->key() == Qt::Key_Escape)
+    {
+        close();
+    }
+#endif
 }

--- a/src/qt/aboutdialog.h
+++ b/src/qt/aboutdialog.h
@@ -1,7 +1,7 @@
 #ifndef ABOUTDIALOG_H
 #define ABOUTDIALOG_H
 
-#include <QDialog>
+#include <QWidget>
 
 namespace Ui {
     class AboutDialog;
@@ -9,7 +9,7 @@ namespace Ui {
 class ClientModel;
 
 /** "About" dialog box */
-class AboutDialog : public QDialog
+class AboutDialog : public QWidget
 {
     Q_OBJECT
 
@@ -20,6 +20,8 @@ public:
     void setModel(ClientModel *model);
 private:
     Ui::AboutDialog *ui;
+
+    void keyPressEvent(QKeyEvent *);
 
 private slots:
     void on_buttonBox_accepted();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -83,7 +83,8 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     aboutQtAction(0),
     trayIcon(0),
     notificator(0),
-    rpcConsole(0)
+    rpcConsole(0),
+    aboutDialog(0)
 {
     resize(850, 550);
     setWindowTitle(tr("NovaCoin") + " - " + tr("Wallet"));
@@ -200,6 +201,8 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     rpcConsole = new RPCConsole(0);
     connect(openRPCConsoleAction, SIGNAL(triggered()), rpcConsole, SLOT(show()));
 
+    aboutDialog = new AboutDialog(0);
+
     // Clicking on "Verify Message" in the address book sends you to the verify message tab
     connect(addressBookPage, SIGNAL(verifyMessage(QString)), this, SLOT(gotoVerifyMessageTab(QString)));
     // Clicking on "Sign Message" in the receive coins page sends you to the sign message tab
@@ -217,6 +220,7 @@ BitcoinGUI::~BitcoinGUI()
 #endif
 
     delete rpcConsole;
+    delete aboutDialog;
 }
 
 void BitcoinGUI::createActions()
@@ -538,9 +542,9 @@ void BitcoinGUI::optionsClicked()
 
 void BitcoinGUI::aboutClicked()
 {
-    AboutDialog dlg;
-    dlg.setModel(clientModel);
-    dlg.exec();
+    aboutDialog->setModel(clientModel);
+    aboutDialog->setWindowModality(Qt::ApplicationModal);
+    aboutDialog->show();
 }
 
 void BitcoinGUI::setNumConnections(int count)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -16,6 +16,7 @@ class SignVerifyMessageDialog;
 class MultisigDialog;
 class Notificator;
 class RPCConsole;
+class AboutDialog;
 
 QT_BEGIN_NAMESPACE
 class QLabel;
@@ -108,6 +109,7 @@ private:
     TransactionView *transactionView;
     MintingView *mintingView;
     RPCConsole *rpcConsole;
+    AboutDialog *aboutDialog;
 
     QMovie *syncIconMovie;
 

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>AboutDialog</class>
- <widget class="QDialog" name="AboutDialog">
+ <widget class="QWidget" name="AboutDialog">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -91,8 +91,11 @@
         <cursorShape>IBeamCursor</cursorShape>
        </property>
        <property name="text">
-        <string>Copyright © 2009-2014 The Bitcoin developers
-Copyright © 2012-2014 The NovaCoin developers</string>
+        <string>Copyright © 2009-2015 The Bitcoin developers
+Copyright © 2011-2012 The PPCoin Developers
+Copyright © 2014 The Peerunity Developers
+Copyright © 2014 The EmerCoin Developers
+Copyright © 2012-2015 The NovaCoin developers</string>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -495,10 +495,16 @@ Reduce the number of addresses involved in the address creation.</source>
     </message>
     <message>
         <location line="+41"/>
-        <source>Copyright © 2009-2014 The Bitcoin developers
-Copyright © 2012-2014 The NovaCoin developers</source>
-        <translation>Все права защищены © 2009-2014 Разработчики Bitcoin
-Все права защищены © 2012-2014 Разработчики NovaCoin</translation>
+        <source>Copyright © 2009-2015 The Bitcoin developers
+Copyright © 2011-2012 The PPCoin Developers
+Copyright © 2014 The Peerunity Developers
+Copyright © 2014 The EmerCoin Developers
+Copyright © 2012-2015 The NovaCoin developers</source>
+        <translation>Все права защищены © 2009-2015 Разработчики Bitcoin
+Все права защищены © 2011-2012 Разработчики PPCoin
+Все права защищены © 2014 Разработчики Peerunity
+Все права защищены © 2014 Разработчики EmerCoin
+Все права защищены © 2012-2015 Разработчики NovaCoin</translation>
     </message>
     <message>
         <location line="+13"/>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -56,7 +56,7 @@ namespace boost {
 # include <sys/prctl.h>
 #endif
 
-#ifndef WIN32
+#if !defined(WIN32) && !defined(ANDROID)
 #include <execinfo.h>
 #endif
 
@@ -1059,7 +1059,7 @@ void LogStackTrace() {
     printf("\n\n******* exception encountered *******\n");
     if (fileout)
     {
-#ifndef WIN32
+#if !defined(WIN32) && !defined(ANDROID)
         void* pszBuffer[32];
         size_t size;
         size = backtrace(pszBuffer, 32);


### PR DESCRIPTION
1) Изменил *#*inсlude , теперь не нужно дополнительно править при построении Android клиента
2) Изменил базовый класс AboutDialog с QDialog на QWidget. В Windows, Linux, Mac, FreeBSD ничего не должно поменяться, но в Android будет заметно. Окно About будет на весь экран. Гораздо удобнее. Нужно будет так же изменить классы у MultisigDialog и CoinControlDialog
3)Обновил дату авторских прав. Так же добавил разработчиков PPCoin, разработчиков Peerunity, разработчиков EmerCoin в список авторов.