### PR TITLE
Coin control

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -752,3 +752,9 @@ void CoinControlDialog::keyPressEvent(QKeyEvent *event)
     }
 #endif
 }
+
+void CoinControlDialog::closeEvent(QCloseEvent* e)
+{
+    QWidget::closeEvent(e);
+    emit beforeClose();
+}

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -21,13 +21,14 @@
 #include <QString>
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
+#include <QKeyEvent>
 
 using namespace std;
 QList<qint64> CoinControlDialog::payAmounts;
 CCoinControl* CoinControlDialog::coinControl = new CCoinControl();
 
 CoinControlDialog::CoinControlDialog(QWidget *parent) :
-    QDialog(parent, DIALOGWINDOWHINTS),
+    QWidget(parent, DIALOGWINDOWHINTS),
     ui(new Ui::CoinControlDialog),
     model(0)
 {
@@ -153,10 +154,9 @@ QString CoinControlDialog::strPad(QString s, int nPadLength, QString sPadding)
 }
 
 // ok button
-void CoinControlDialog::buttonBoxClicked(QAbstractButton* button)
+void CoinControlDialog::on_buttonBox_accepted()
 {
-    if (ui->buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole)
-        done(QDialog::Accepted); // closes the dialog
+    close(); // closes the dialog
 }
 
 // (un)select all
@@ -416,7 +416,7 @@ QString CoinControlDialog::getPriorityLabel(double dPriority)
     else ui->labelLocked->setVisible(false);
 }*/
 
-void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
+void CoinControlDialog::updateLabels(WalletModel *model, QWidget* dialog)
 {
     if (!model) return;
 
@@ -736,4 +736,19 @@ void CoinControlDialog::updateView()
     // sort view
     sortView(sortColumn, sortOrder);
     ui->treeWidget->setEnabled(true);
+}
+
+void CoinControlDialog::keyPressEvent(QKeyEvent *event)
+{
+#ifdef ANDROID
+    if(event->key() == Qt::Key_Back)
+    {
+        close();
+    }
+#else
+    if(event->key() == Qt::Key_Escape)
+    {
+        close();
+    }
+#endif
 }

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -19,6 +19,8 @@ class CCoinControl;
 class CoinControlDialog : public QWidget
 {
     Q_OBJECT
+signals:
+    void beforeClose();
 
 public:
     explicit CoinControlDialog(QWidget *parent = 0);
@@ -32,6 +34,9 @@ public:
 
     static QList<qint64> payAmounts;
     static CCoinControl *coinControl;
+
+protected:
+    void closeEvent(QCloseEvent* e);
 
 private:
     Ui::CoinControlDialog *ui;

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -3,7 +3,7 @@
 
 #include <QAbstractButton>
 #include <QAction>
-#include <QDialog>
+#include <QWidget>
 #include <QList>
 #include <QMenu>
 #include <QPoint>
@@ -16,7 +16,7 @@ namespace Ui {
 class WalletModel;
 class CCoinControl;
 
-class CoinControlDialog : public QDialog
+class CoinControlDialog : public QWidget
 {
     Q_OBJECT
 
@@ -27,7 +27,7 @@ public:
     void setModel(WalletModel *model);
 
     // static because also called from sendcoinsdialog
-    static void updateLabels(WalletModel*, QDialog*);
+    static void updateLabels(WalletModel*, QWidget*);
     static QString getPriorityLabel(double);
 
     static QList<qint64> payAmounts;
@@ -48,6 +48,8 @@ private:
     QString strPad(QString, int, QString);
     void sortView(int, Qt::SortOrder);
     void updateView();
+
+    void keyPressEvent(QKeyEvent *);
 
     enum
     {
@@ -85,7 +87,7 @@ private slots:
     void radioListMode(bool);
     void viewItemChanged(QTreeWidgetItem*, int);
     void headerSectionClicked(int);
-    void buttonBoxClicked(QAbstractButton*);
+    void on_buttonBox_accepted();
     void buttonSelectAllClicked();
     //void updateLabelLocked();
 };

--- a/src/qt/coincontroltreewidget.cpp
+++ b/src/qt/coincontroltreewidget.cpp
@@ -13,7 +13,8 @@ void CoinControlTreeWidget::keyPressEvent(QKeyEvent *event)
     {
         event->ignore();
         int COLUMN_CHECKBOX = 0;
-        this->currentItem()->setCheckState(COLUMN_CHECKBOX, ((this->currentItem()->checkState(COLUMN_CHECKBOX) == Qt::Checked) ? Qt::Unchecked : Qt::Checked));
+        if(this->currentItem())
+            this->currentItem()->setCheckState(COLUMN_CHECKBOX, ((this->currentItem()->checkState(COLUMN_CHECKBOX) == Qt::Checked) ? Qt::Unchecked : Qt::Checked));
     }
     else if (event->key() == Qt::Key_Escape) // press esc -> close dialog
     {

--- a/src/qt/coincontroltreewidget.cpp
+++ b/src/qt/coincontroltreewidget.cpp
@@ -16,11 +16,15 @@ void CoinControlTreeWidget::keyPressEvent(QKeyEvent *event)
         if(this->currentItem())
             this->currentItem()->setCheckState(COLUMN_CHECKBOX, ((this->currentItem()->checkState(COLUMN_CHECKBOX) == Qt::Checked) ? Qt::Unchecked : Qt::Checked));
     }
+#ifdef ANDROID
+    else if (event->key() == Qt::Key_Back) // press back -> close dialog
+#else
     else if (event->key() == Qt::Key_Escape) // press esc -> close dialog
+#endif
     {
         event->ignore();
         CoinControlDialog *coinControlDialog = (CoinControlDialog*)this->parentWidget();
-        coinControlDialog->done(QDialog::Accepted);
+        coinControlDialog->close();
     }
     else
     {

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>CoinControlDialog</class>
- <widget class="QDialog" name="CoinControlDialog">
+ <widget class="QWidget" name="CoinControlDialog">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -81,8 +81,7 @@ SendCoinsDialog::SendCoinsDialog(QWidget *parent) :
     fNewRecipientAllowed = true;
 
     coinControl = new CoinControlDialog(0);
-    QAction *updateLabes = new QAction(coinControl);
-    connect(updateLabes, SIGNAL(close()), this, SLOT(coinControlUpdateLabels()));
+    connect(coinControl, SIGNAL(beforeClose()), this, SLOT(coinControlUpdateLabels()));
 }
 
 void SendCoinsDialog::setModel(WalletModel *model)

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -26,7 +26,8 @@
 SendCoinsDialog::SendCoinsDialog(QWidget *parent) :
     QDialog(parent, DIALOGWINDOWHINTS),
     ui(new Ui::SendCoinsDialog),
-    model(0)
+    model(0),
+    coinControl(0)
 {
     ui->setupUi(this);
 
@@ -78,6 +79,10 @@ SendCoinsDialog::SendCoinsDialog(QWidget *parent) :
     ui->labelCoinControlChange->addAction(clipboardChangeAction);
 
     fNewRecipientAllowed = true;
+
+    coinControl = new CoinControlDialog(0);
+    QAction *updateLabes = new QAction(coinControl);
+    connect(updateLabes, SIGNAL(close()), this, SLOT(coinControlUpdateLabels()));
 }
 
 void SendCoinsDialog::setModel(WalletModel *model)
@@ -109,6 +114,7 @@ void SendCoinsDialog::setModel(WalletModel *model)
 
 SendCoinsDialog::~SendCoinsDialog()
 {
+    delete coinControl;
     delete ui;
 }
 
@@ -444,10 +450,9 @@ void SendCoinsDialog::coinControlFeatureChanged(bool checked)
 // Coin Control: button inputs -> show actual coin control dialog
 void SendCoinsDialog::coinControlButtonClicked()
 {
-    CoinControlDialog dlg;
-    dlg.setModel(model);
-    dlg.exec();
-    coinControlUpdateLabels();
+    coinControl->setModel(model);
+    coinControl->setWindowModality(Qt::ApplicationModal);
+    coinControl->show();
 }
 
 // Coin Control: checkbox custom change address

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -10,6 +10,7 @@ namespace Ui {
 class WalletModel;
 class SendCoinsEntry;
 class SendCoinsRecipient;
+class CoinControlDialog;
 
 QT_BEGIN_NAMESPACE
 class QUrl;
@@ -48,6 +49,7 @@ private:
     Ui::SendCoinsDialog *ui;
     WalletModel *model;
     bool fNewRecipientAllowed;
+    CoinControlDialog *coinControl;
 
 private slots:
     void on_sendButton_clicked();


### PR DESCRIPTION
1) Был баг: Если в CoinControl кликнуть мышкой в область с деревом входов, но не выбирать ни один вход и нажать "пробел", то будет вылет. 
Исправление падения при нажатии пробела в CC решило это.
(this->currentItem() возвращает текущий элемент в виджете-дереве, если не выбрано элементов, то возвращает NULL)
2) Изменён базовый класс для CoinControl на QWidget