### PR TITLE
использовать UTF8 знак примерно равно

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -539,7 +539,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QWidget* dialog)
     l2->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nAmount));            // Amount
     l3->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nPayFee, false, 3));  // Fee
     l4->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nAfterFee));          // After Fee
-    l5->setText(((nBytes > 0) ? "~" : "") + QString::number(nBytes));            // Bytes
+    l5->setText(((nBytes > 0) ? ASYMP_UTF8 : "") + QString::number(nBytes));     // Bytes
     l6->setText(sPriorityLabel);                                                 // Priority
     l7->setText((fLowOutput ? (fDust ? tr("DUST") : tr("yes")) : tr("no")));     // Low Output / Dust
     l8->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nChange));            // Change

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -16,6 +16,8 @@ namespace Ui {
 class WalletModel;
 class CCoinControl;
 
+#define ASYMP_UTF8 "\xE2\x89\x88"
+
 class CoinControlDialog : public QWidget
 {
     Q_OBJECT


### PR DESCRIPTION
![примерно равно](http://i60.tinypic.com/2h7kv8j.jpg)
Увидел здесь: https://github.com/bitcoin/bitcoin/pull/5651
У нас меньше исправлений, потому что у нас комиссия зависит от целового количества килобайт, а не просто от количества байт. И потому что при копировании копируется значение целиком, вместе со знаком. То есть ≈226 и ~226, а не просто число. Но я не думаю что нужно это менять, так как при вставке ,например, в калькулятор, калькулятор нормально воспринимает это как 226.