### PR TITLE
правильно показывать метку адреса в multisigdialog

### DIFF
--- a/src/qt/multisigaddressentry.cpp
+++ b/src/qt/multisigaddressentry.cpp
@@ -92,6 +92,8 @@ void MultisigAddressEntry::on_pubkey_textChanged(const QString &pubkey)
     QString associatedLabel = model->getAddressTableModel()->labelForAddress(address.ToString().c_str());
     if(!associatedLabel.isEmpty())
         ui->label->setText(associatedLabel);
+    else
+        ui->label->setText(QString());
 }
 
 void MultisigAddressEntry::on_address_textChanged(const QString &address)


### PR DESCRIPTION
Описание проблемы:
1)Откройте окно для работы с мультиподписью(файл -> мультиподпись)
2)Выберите адрес с меткой
3)Выберите другой адрес без метки, но в поле "Метка" останется  метка предыдущего адреса.

Этот патч решает описанную выше проблему.