### PR TITLE
обновление библиотек для MSVC сборки

### DIFF
--- a/MSVC/build-helpers/buildboost.bat
+++ b/MSVC/build-helpers/buildboost.bat
@@ -1,5 +1,5 @@
 @ECHO ON
-cd C:\MyProjects\Deps\boost_1_55_0
+cd C:\MyProjects\Deps\boost_1_57_0
 if %errorlevel% NEQ 0 goto ERRORCLEANUP
 md stage\lib\x64
 call "C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat" x86_amd64

--- a/MSVC/build-helpers/buildopenssl.bat
+++ b/MSVC/build-helpers/buildopenssl.bat
@@ -1,6 +1,6 @@
 @ECHO ON
 SET OLDPATH=%PATH%
-cd C:\MyProjects\Deps\openssl-1.0.1j
+cd C:\MyProjects\Deps\openssl-1.0.2
 if %errorlevel% NEQ 0 goto ERRORCLEANUP
 REM first change the debug compiler options
 perl -pi.bak -e "s#/Zi#/Z7#g;" util/pl/VC-32.pl

--- a/MSVC/libcommon/libcommon.vcxproj
+++ b/MSVC/libcommon/libcommon.vcxproj
@@ -158,8 +158,8 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level1</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>MINIUPNP_STATICLIB;STATICLIB;USE_UPNP;_CRT_SECURE_NO_WARNINGS;UNICODE;WIN32;_SCL_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;HAVE_WORKING_BOOST_SLEEP_FOR;_WINSOCKAPI_;NOMINMAX;USE_LEVELDB;USE_IPV6=1;BOOST_SPIRIT_THREADSAFE;__STDC_FORMAT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\include;..\..\..\Deps;..\..\..\deps\openssl-1.0.1j\inc32;..\..\..\src\leveldb\helpers\memenv;..\..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_55_0;..\..\..\deps\boost_1_55_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>MINIUPNP_STATICLIB;STATICLIB;USE_UPNP;_CRT_SECURE_NO_WARNINGS;UNICODE;WIN32;_SCL_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;HAVE_WORKING_BOOST_SLEEP_FOR;NOMINMAX;USE_LEVELDB;USE_IPV6=1;BOOST_SPIRIT_THREADSAFE;__STDC_FORMAT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\include;..\..\..\Deps;..\..\..\deps\openssl-1.0.2\inc32;..\..\..\src\leveldb\helpers\memenv;..\..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_57_0;..\..\..\deps\boost_1_57_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
@@ -179,8 +179,8 @@
       </PrecompiledHeader>
       <WarningLevel>Level1</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>MINIUPNP_STATICLIB;STATICLIB;USE_UPNP;_CRT_SECURE_NO_WARNINGS;UNICODE;WIN32;_WIN32;_SCL_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;HAVE_WORKING_BOOST_SLEEP_FOR;_WINSOCKAPI_;NOMINMAX;USE_LEVELDB;USE_IPV6=1;BOOST_SPIRIT_THREADSAFE;__STDC_FORMAT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\include;..\..\..\Deps;..\..\..\deps\openssl-1.0.1j\inc32;..\..\..\src\leveldb\helpers\memenv;..\..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_55_0;..\..\..\deps\boost_1_55_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>MINIUPNP_STATICLIB;STATICLIB;USE_UPNP;_CRT_SECURE_NO_WARNINGS;UNICODE;WIN32;_WIN32;_SCL_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;HAVE_WORKING_BOOST_SLEEP_FOR;NOMINMAX;USE_LEVELDB;USE_IPV6=1;BOOST_SPIRIT_THREADSAFE;__STDC_FORMAT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\include;..\..\..\Deps;..\..\..\deps\openssl-1.0.2\inc32;..\..\..\src\leveldb\helpers\memenv;..\..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_57_0;..\..\..\deps\boost_1_57_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
@@ -200,8 +200,8 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>MINIUPNP_STATICLIB;STATICLIB;USE_UPNP;_CRT_SECURE_NO_WARNINGS;UNICODE;WIN32;_SCL_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;HAVE_WORKING_BOOST_SLEEP_FOR;_WINSOCKAPI_;NOMINMAX;USE_LEVELDB;USE_IPV6=1;BOOST_SPIRIT_THREADSAFE;__STDC_FORMAT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\include;..\..\..\deps\;..\..\..\deps\openssl-1.0.1j\inc32;..\..\..\src\leveldb\helpers\memenv;..\..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_55_0;..\..\..\deps\boost_1_55_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>MINIUPNP_STATICLIB;STATICLIB;USE_UPNP;_CRT_SECURE_NO_WARNINGS;UNICODE;WIN32;_SCL_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;HAVE_WORKING_BOOST_SLEEP_FOR;NOMINMAX;USE_LEVELDB;USE_IPV6=1;BOOST_SPIRIT_THREADSAFE;__STDC_FORMAT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\include;..\..\..\deps\;..\..\..\deps\openssl-1.0.2\inc32;..\..\..\src\leveldb\helpers\memenv;..\..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_57_0;..\..\..\deps\boost_1_57_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
@@ -223,8 +223,8 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>MINIUPNP_STATICLIB;STATICLIB;USE_UPNP;_CRT_SECURE_NO_WARNINGS;UNICODE;WIN32;_SCL_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;HAVE_WORKING_BOOST_SLEEP_FOR;_WINSOCKAPI_;NOMINMAX;USE_LEVELDB;USE_IPV6=1;BOOST_SPIRIT_THREADSAFE;__STDC_FORMAT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\include;..\..\..\Deps;..\..\..\deps\openssl-1.0.1j\inc32;..\..\..\src\leveldb\helpers\memenv;..\..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_55_0;..\..\..\deps\boost_1_55_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>MINIUPNP_STATICLIB;STATICLIB;USE_UPNP;_CRT_SECURE_NO_WARNINGS;UNICODE;WIN32;_SCL_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;HAVE_WORKING_BOOST_SLEEP_FOR;NOMINMAX;USE_LEVELDB;USE_IPV6=1;BOOST_SPIRIT_THREADSAFE;__STDC_FORMAT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\include;..\..\..\Deps;..\..\..\deps\openssl-1.0.2\inc32;..\..\..\src\leveldb\helpers\memenv;..\..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_57_0;..\..\..\deps\boost_1_57_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>

--- a/MSVC/mynovacoin/mynovacoin.vcxproj
+++ b/MSVC/mynovacoin/mynovacoin.vcxproj
@@ -42,7 +42,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v110_xp</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -86,7 +87,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>USE_UPNP;UNICODE;WIN32;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;USE_LEVELDB;USE_IPV6=1;__STDC_FORMAT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\include;..\..\src\leveldb\include;..\..\..\deps\openssl-1.0.1j\inc32;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_55_0;..\..\..\deps\boost_1_55_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\src\leveldb\include;..\..\..\deps\openssl-1.0.2\inc32;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_57_0;..\..\..\deps\boost_1_57_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -98,7 +99,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <OutputFile>$(OutDir)\$(ProjectName).exe</OutputFile>
-      <AdditionalLibraryDirectories>..\..\..\Deps\miniupnpc\msvc\Debug;..\..\..\Deps\db-6.0.20\build_windows\Win32\Static Debug;..\..\..\deps\boost_1_55_0\stage\lib;..\..\..\deps\openssl-1.0.1j\out32.dbg;$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\Deps\miniupnpc\msvc\Debug;..\..\..\Deps\db-6.0.20\build_windows\Win32\Static Debug;..\..\..\deps\boost_1_57_0\stage\lib;..\..\..\deps\openssl-1.0.2\out32.dbg;$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>iphlpapi.lib;miniupnpc.lib;kernel32.lib;user32.lib;shell32.lib;uuid.lib;ole32.lib;advapi32.lib;ws2_32.lib;gdi32.lib;comdlg32.lib;oleaut32.lib;imm32.lib;winmm.lib;winspool.lib;ssleay32.lib;libeay32.lib;libdb60sd.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
@@ -106,7 +107,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PreprocessorDefinitions>USE_UPNP;UNICODE;WIN32;_WIN32;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;USE_LEVELDB;USE_IPV6=1;__STDC_FORMAT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\include;..\..\src\leveldb\include;..\..\..\Deps\openssl-1.0.1j\inc32;..\..\..\Deps\db-6.0.20\build_windows;..\..\..\Deps\boost_1_55_0;..\..\..\Deps\boost_1_55_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\src\leveldb\include;..\..\..\Deps\openssl-1.0.2\inc32;..\..\..\Deps\db-6.0.20\build_windows;..\..\..\Deps\boost_1_57_0;..\..\..\Deps\boost_1_57_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -118,7 +119,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <OutputFile>$(OutDir)\$(ProjectName).exe</OutputFile>
-      <AdditionalLibraryDirectories>..\..\..\Deps\miniupnpc\msvc\x64\Debug;..\..\..\Deps\db-6.0.20\build_windows\x64\Static Debug;..\..\..\Deps\boost_1_55_0\stage\lib\x64;..\..\..\Deps\openssl-1.0.1j\out64.dbg;$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\Deps\miniupnpc\msvc\x64\Debug;..\..\..\Deps\db-6.0.20\build_windows\x64\Static Debug;..\..\..\Deps\boost_1_57_0\stage\lib\x64;..\..\..\Deps\openssl-1.0.2\out64.dbg;$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>iphlpapi.lib;miniupnpc.lib;kernel32.lib;user32.lib;shell32.lib;uuid.lib;ole32.lib;advapi32.lib;ws2_32.lib;gdi32.lib;comdlg32.lib;oleaut32.lib;imm32.lib;winmm.lib;winspool.lib;ssleay32.lib;libeay32.lib;libdb60sd.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
@@ -126,17 +127,22 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>USE_UPNP;UNICODE;WIN32;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;USE_LEVELDB;USE_IPV6=1;__STDC_FORMAT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\include;..\..\src\leveldb\include;..\..\..\deps\openssl-1.0.1j\inc32;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_55_0;..\..\..\deps\boost_1_55_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\src\leveldb\include;..\..\..\deps\openssl-1.0.2\inc32;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_57_0;..\..\..\deps\boost_1_57_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <OutputFile>$(OutDir)\$(ProjectName).exe</OutputFile>
-      <AdditionalLibraryDirectories>..\..\..\deps\miniupnpc\msvc\Release;..\..\..\deps\db-6.0.20\build_windows\Win32\Static Release;..\..\..\deps\boost_1_55_0\stage\lib;..\..\..\deps\openssl-1.0.1j\out32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\deps\miniupnpc\msvc\Release;..\..\..\deps\db-6.0.20\build_windows\Win32\Static Release;..\..\..\deps\boost_1_57_0\stage\lib;..\..\..\deps\openssl-1.0.2\out32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>miniupnpc.lib;kernel32.lib;user32.lib;shell32.lib;uuid.lib;ole32.lib;advapi32.lib;ws2_32.lib;gdi32.lib;comdlg32.lib;oleaut32.lib;imm32.lib;winmm.lib;winspool.lib;ssleay32.lib;libeay32.lib;libdb60s.lib;Shlwapi.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
@@ -144,17 +150,22 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PreprocessorDefinitions>USE_UPNP;UNICODE;WIN32;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;USE_LEVELDB;USE_IPV6=1;__STDC_FORMAT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\include;..\..\src\leveldb\include;..\..\..\Deps\openssl-1.0.1j\inc32;..\..\..\Deps\db-6.0.20\build_windows;..\..\..\Deps\boost_1_55_0;..\..\..\Deps\boost_1_55_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\src\leveldb\include;..\..\..\Deps\openssl-1.0.2\inc32;..\..\..\Deps\db-6.0.20\build_windows;..\..\..\Deps\boost_1_57_0;..\..\..\Deps\boost_1_57_0\boost;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <OutputFile>$(OutDir)\$(ProjectName).exe</OutputFile>
-      <AdditionalLibraryDirectories>..\..\..\Deps\miniupnpc\msvc\x64\Release;..\..\..\Deps\db-6.0.20\build_windows\x64\Static Release;..\..\..\Deps\boost_1_55_0\stage\lib\x64;..\..\..\Deps\openssl-1.0.1j\out64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\Deps\miniupnpc\msvc\x64\Release;..\..\..\Deps\db-6.0.20\build_windows\x64\Static Release;..\..\..\Deps\boost_1_57_0\stage\lib\x64;..\..\..\Deps\openssl-1.0.2\out64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>iphlpapi.lib;miniupnpc.lib;kernel32.lib;user32.lib;shell32.lib;uuid.lib;ole32.lib;advapi32.lib;ws2_32.lib;gdi32.lib;comdlg32.lib;oleaut32.lib;imm32.lib;winmm.lib;winspool.lib;ssleay32.lib;libeay32.lib;libdb60s.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>

--- a/MSVC/mynovacoinqt/mynovacoinqt.vcxproj
+++ b/MSVC/mynovacoinqt/mynovacoinqt.vcxproj
@@ -48,7 +48,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <IntermediateDirectory>build\</IntermediateDirectory>
     <PrimaryOutput>mynovacoinqt</PrimaryOutput>
-    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <PlatformToolSet>v110_xp</PlatformToolSet>
@@ -94,7 +94,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;..\..\..\deps\qrencode-win32;..\..\..\deps\openssl-1.0.1j\inc32;..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_55_0;..\..\..\deps\boost_1_55_0\boost;..\..\src\qt\forms;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories);..\..\src;..\..\src\json;..\..\src\qt;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtWidgets;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtNetwork;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtGui;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtCore;.\build</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\..\deps\qrencode-win32;..\..\..\deps\openssl-1.0.2\inc32;..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_57_0;..\..\..\deps\boost_1_57_0\boost;..\..\src\qt\forms;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories);..\..\src;..\..\src\json;..\..\src\qt;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtWidgets;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtNetwork;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtGui;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtCore;.\build</AdditionalIncludeDirectories>
       <AdditionalOptions>
       </AdditionalOptions>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
@@ -113,7 +113,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>libcommon.lib;leveldb.lib;miniupnpc.lib;iphlpapi.lib;ssleay32.lib;libeay32.lib;lib-qrcode.lib;libdb60sd.lib;Shlwapi.lib;%(AdditionalDependencies);ws2_32.lib;imm32.lib;winmm.lib;qtmaind.lib;Qt5Cored.lib;Qt5Guid.lib;Qt5Widgetsd.lib;Qt5Networkd.lib;qwindowsd.lib;Qt5PlatformSupportD.lib;qtaccessiblewidgetsd.lib;qgenericbearerd.lib;qnativewifibearerd.lib;qddsd.lib;qicnsd.lib;qicod.lib;qjp2d.lib;qmngd.lib;qsvgd.lib;qtgad.lib;qtiffd.lib;qwbmpd.lib;qwebpd.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\deps\miniupnpc\msvc\debug;..\..\..\deps\boost_1_55_0\stage\lib;..\..\..\Deps\qrencode-win32\vc8\Debug;..\..\..\Deps\db-6.0.20\build_windows\Win32\Static Debug;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\lib;..\..\..\deps\openssl-1.0.1j\out32.dbg;..\..\..\deps\openssl-1.0.1j\out32;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\accessible;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\bearer;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\platforms;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\imageformats;$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\deps\miniupnpc\msvc\debug;..\..\..\deps\boost_1_57_0\stage\lib;..\..\..\Deps\qrencode-win32\vc8\Debug;..\..\..\Deps\db-6.0.20\build_windows\Win32\Static Debug;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\lib;..\..\..\deps\openssl-1.0.2\out32.dbg;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\accessible;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\bearer;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\platforms;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\imageformats;$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>
       </AdditionalOptions>
       <DataExecutionPrevention>true</DataExecutionPrevention>
@@ -143,7 +143,7 @@ C:\MyProjects\Deps\qt-everywhere-opensource-src-5.3.2\qtbase\bin\lrelease C:\MyP
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;..\..\..\deps\qrencode-win32;..\..\..\deps\openssl-1.0.1j\inc32;..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_55_0;..\..\..\deps\boost_1_55_0\boost;..\..\src\qt\forms;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories);..\..\src;..\..\src\json;..\..\src\qt;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtWidgets;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtNetwork;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtGui;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtCore;.\build</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\..\deps\qrencode-win32;..\..\..\deps\openssl-1.0.2\inc32;..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_57_0;..\..\..\deps\boost_1_57_0\boost;..\..\src\qt\forms;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;%(AdditionalIncludeDirectories);..\..\src;..\..\src\json;..\..\src\qt;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtWidgets;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtNetwork;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtGui;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtCore;.\build</AdditionalIncludeDirectories>
       <AdditionalOptions>
       </AdditionalOptions>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
@@ -162,7 +162,7 @@ C:\MyProjects\Deps\qt-everywhere-opensource-src-5.3.2\qtbase\bin\lrelease C:\MyP
     </ClCompile>
     <Link>
       <AdditionalDependencies>libcommon.lib;leveldb.lib;miniupnpc.lib;iphlpapi.lib;ssleay32.lib;libeay32.lib;lib-qrcode.lib;libdb60sd.lib;Shlwapi.lib;%(AdditionalDependencies);ws2_32.lib;imm32.lib;winmm.lib;qtmaind.lib;Qt5Cored.lib;Qt5Guid.lib;Qt5Widgetsd.lib;Qt5Networkd.lib;qwindowsd.lib;Qt5PlatformSupportD.lib;qtaccessiblewidgetsd.lib;qgenericbearerd.lib;qnativewifibearerd.lib;qddsd.lib;qicnsd.lib;qicod.lib;qjp2d.lib;qmngd.lib;qsvgd.lib;qtgad.lib;qtiffd.lib;qwbmpd.lib;qwebpd.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\deps\miniupnpc\msvc\x64\debug;..\..\..\deps\boost_1_55_0\stage\lib\x64;..\..\..\Deps\qrencode-win32\vc8\x64\Debug;..\..\..\Deps\db-6.0.20\build_windows\x64\Static Debug;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\lib;..\..\..\deps\openssl-1.0.1j\out64.dbg;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\accessible;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\bearer;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\platforms;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\imageformats;$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\deps\miniupnpc\msvc\x64\debug;..\..\..\deps\boost_1_57_0\stage\lib\x64;..\..\..\Deps\qrencode-win32\vc8\x64\Debug;..\..\..\Deps\db-6.0.20\build_windows\x64\Static Debug;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\lib;..\..\..\deps\openssl-1.0.2\out64.dbg;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\accessible;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\bearer;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\platforms;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\imageformats;$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>
       </AdditionalOptions>
       <DataExecutionPrevention>true</DataExecutionPrevention>
@@ -192,7 +192,7 @@ C:\MyProjects\Deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\bin\lrelease C:\
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;..\..\..\deps\qrencode-win32;..\..\..\deps\openssl-1.0.1j\inc32;..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_55_0;..\..\..\deps\boost_1_55_0\boost;..\..\src\qt\forms;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;..\..\src;..\..\src\qt;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtWidgets;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtNetwork;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtGui;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtCore;.\build;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\..\deps\qrencode-win32;..\..\..\deps\openssl-1.0.2\inc32;..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_57_0;..\..\..\deps\boost_1_57_0\boost;..\..\src\qt\forms;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;..\..\src;..\..\src\qt;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtWidgets;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtNetwork;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtGui;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\include\QtCore;.\build;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>
       </AdditionalOptions>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
@@ -200,7 +200,7 @@ C:\MyProjects\Deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\bin\lrelease C:\
       <DebugInformationFormat>None</DebugInformationFormat>
       <ExceptionHandling>Sync</ExceptionHandling>
       <ObjectFileName>$(IntDir)</ObjectFileName>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <PreprocessorDefinitions>USE_UPNP;USE_QRCODE;UNICODE;WIN32;QT_CORE_LIB;QT_GUI_LIB;QT_WIDGETS_LIB;QT_GUI;_SCL_SECURE_NO_WARNINGS;USE_LEVELDB;USE_IPV6=1;__STDC_FORMAT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessToFile>false</PreprocessToFile>
       <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>
@@ -209,10 +209,16 @@ C:\MyProjects\Deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\bin\lrelease C:\
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <WarningLevel>Level3</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <AdditionalDependencies>miniupnpc.lib;iphlpapi.lib;kernel32.lib;user32.lib;shell32.lib;uuid.lib;ssleay32.lib;libeay32.lib;lib-qrcode.lib;libdb60s.lib;Shlwapi.lib;%(AdditionalDependencies);ole32.lib;advapi32.lib;ws2_32.lib;gdi32.lib;comdlg32.lib;oleaut32.lib;imm32.lib;winmm.lib;qtmain.lib;Qt5Core.lib;Qt5Gui.lib;Qt5Widgets.lib;Qt5Network.lib;qwindows.lib;Qt5PlatformSupport.lib;qtaccessiblewidgets.lib;qgenericbearer.lib;qnativewifibearer.lib;qdds.lib;qicns.lib;qico.lib;qjp2.lib;qmng.lib;qsvg.lib;qtga.lib;qtiff.lib;qwbmp.lib;qwebp.lib;libcommon.lib;leveldb.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\lib;..\..\..\deps\openssl-1.0.1j\out32.dbg;..\..\..\deps\openssl-1.0.1j\out32;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\accessible;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\bearer;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\platforms;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\imageformats;..\..\..\deps\miniupnpc\msvc\release\;..\..\..\deps\boost_1_55_0\stage\lib;..\..\..\Deps\qrencode-win32\vc8\Release\;..\..\..\Deps\db-6.0.20\build_windows\Win32\Static Release;$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\lib;..\..\..\deps\openssl-1.0.2\out32.dbg;..\..\..\deps\openssl-1.0.2\out32;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\accessible;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\bearer;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\platforms;..\..\..\deps\qt-everywhere-opensource-src-5.3.2\qtbase\plugins\imageformats;..\..\..\deps\miniupnpc\msvc\release\;..\..\..\deps\boost_1_57_0\stage\lib;..\..\..\Deps\qrencode-win32\vc8\Release\;..\..\..\Deps\db-6.0.20\build_windows\Win32\Static Release;$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>"/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' publicKeyToken='6595b64144ccf1df' language='*' processorArchitecture='*'" %(AdditionalOptions)</AdditionalOptions>
       <DataExecutionPrevention>true</DataExecutionPrevention>
       <GenerateDebugInformation>false</GenerateDebugInformation>
@@ -239,7 +245,7 @@ C:\MyProjects\Deps\qt-everywhere-opensource-src-5.3.2\qtbase\bin\lrelease C:\MyP
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\include;..\..\..\deps\qrencode-win32;..\..\..\deps\openssl-1.0.1j\inc32;..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_55_0;..\..\..\deps\boost_1_55_0\boost;..\..\src\qt\forms;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;..\..\src;..\..\src\qt;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\include;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\include\QtWidgets;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\include\QtNetwork;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\include\QtGui;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\include\QtCore;.\build;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\..\deps\qrencode-win32;..\..\..\deps\openssl-1.0.2\inc32;..\src\leveldb\helpers;..\..\src\leveldb\include;..\..\..\deps\db-6.0.20\build_windows;..\..\..\deps\boost_1_57_0;..\..\..\deps\boost_1_57_0\boost;..\..\src\qt\forms;.\GeneratedFiles;.\GeneratedFiles\$(ConfigurationName);.\;..\..\src;..\..\src\qt;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\include;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\include\QtWidgets;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\include\QtNetwork;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\include\QtGui;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\include\QtCore;.\build;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>
       </AdditionalOptions>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
@@ -247,7 +253,7 @@ C:\MyProjects\Deps\qt-everywhere-opensource-src-5.3.2\qtbase\bin\lrelease C:\MyP
       <DebugInformationFormat>None</DebugInformationFormat>
       <ExceptionHandling>Sync</ExceptionHandling>
       <ObjectFileName>$(IntDir)</ObjectFileName>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <PreprocessorDefinitions>USE_UPNP;USE_QRCODE;UNICODE;WIN32;QT_CORE_LIB;QT_GUI_LIB;QT_WIDGETS_LIB;QT_GUI;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;USE_LEVELDB;USE_IPV6=1;__STDC_FORMAT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessToFile>false</PreprocessToFile>
       <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>
@@ -256,10 +262,15 @@ C:\MyProjects\Deps\qt-everywhere-opensource-src-5.3.2\qtbase\bin\lrelease C:\MyP
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <WarningLevel>Level3</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
     </ClCompile>
     <Link>
       <AdditionalDependencies>miniupnpc.lib;iphlpapi.lib;kernel32.lib;user32.lib;shell32.lib;uuid.lib;ssleay32.lib;libeay32.lib;lib-qrcode.lib;libdb60s.lib;Shlwapi.lib;%(AdditionalDependencies);ole32.lib;advapi32.lib;ws2_32.lib;gdi32.lib;comdlg32.lib;oleaut32.lib;imm32.lib;winmm.lib;qtmain.lib;Qt5Core.lib;Qt5Gui.lib;Qt5Widgets.lib;Qt5Network.lib;qwindows.lib;Qt5PlatformSupport.lib;qtaccessiblewidgets.lib;qgenericbearer.lib;qnativewifibearer.lib;qdds.lib;qicns.lib;qico.lib;qjp2.lib;qmng.lib;qsvg.lib;qtga.lib;qtiff.lib;qwbmp.lib;qwebp.lib;libcommon.lib;leveldb.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\lib;..\..\..\deps\openssl-1.0.1j\out64.dbg;..\..\..\deps\openssl-1.0.1j\out64;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\accessible;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\bearer;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\platforms;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\imageformats;..\..\..\deps\miniupnpc\msvc\x64\release\;..\..\..\deps\boost_1_55_0\stage\lib\x64;..\..\..\Deps\qrencode-win32\vc8\x64\Release\;..\..\..\Deps\db-6.0.20\build_windows\x64\Static Release;$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\lib;..\..\..\deps\openssl-1.0.1j\out64.dbg;..\..\..\deps\openssl-1.0.2\out64;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\accessible;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\bearer;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\platforms;..\..\..\deps\qt-everywhere-opensource-src-5.3.2-64\qtbase\plugins\imageformats;..\..\..\deps\miniupnpc\msvc\x64\release\;..\..\..\deps\boost_1_57_0\stage\lib\x64;..\..\..\Deps\qrencode-win32\vc8\x64\Release\;..\..\..\Deps\db-6.0.20\build_windows\x64\Static Release;$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>"/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' publicKeyToken='6595b64144ccf1df' language='*' processorArchitecture='*'" %(AdditionalOptions)</AdditionalOptions>
       <DataExecutionPrevention>true</DataExecutionPrevention>
       <GenerateDebugInformation>false</GenerateDebugInformation>

--- a/doc/building novacoind and novacoinqt under Windows with MSVC.txt
+++ b/doc/building novacoind and novacoinqt under Windows with MSVC.txt
@@ -23,7 +23,7 @@ http://sourceforge.net/projects/nasm/files/latest/download
 Скопируйте папку build-helpers(находится в архиве с исходниками в папке MSVC) и вставьте в папку C:\MyProjects\Deps
 
 2.1 OpenSSL 
--Скачайте http://www.openssl.org/source/openssl-1.0.1j.tar.gz
+-Скачайте http://www.openssl.org/source/openssl-1.0.2.tar.gz
 -Распакуйте архив в папку C:\MyProjects\Deps
 -Откройте командную строку Windows и выполните следующий код:
 
@@ -49,8 +49,8 @@ C:\MyProjects\Deps\db-6.0.20\build_windows\x64\Static Release\libdb60s.lib
 C:\MyProjects\Deps\db-6.0.20\build_windows\x64\Static Debug\libdb60sd.lib
 
 2.3 Boost
--Скачайте http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.7z/download
--Распакуйте boost_1_55_0.7z в папку C:\MyProjects\Deps
+-Скачайте http://sourceforge.net/projects/boost/files/boost/1.57.0/boost_1_57_0.7z/download
+-Распакуйте boost_1_57_0.7z в папку C:\MyProjects\Deps
 -Откройте командную строку Windows и выполните следующий код:
 
 cd C:\MyProjects\Deps\build-helpers


### PR DESCRIPTION
1)Обновил OpenSSL до 1.0.2
2)Обновил Boost до 1.57
3)Убрал определение препроцессора: *_*WINSOCKAPI*_*  .  Оно стало не нужно после этого коммита: https://github.com/novacoin-project/novacoin/commit/5fddc4755daf043e8e927fd97bf2c80ad9d819e5
4)Немного изменил флаги оптимизации программы.