### PR TITLE
sha512 шифрование имеет индекс 0, а не 1

### DIFF
--- a/src/crypter.h
+++ b/src/crypter.h
@@ -53,7 +53,7 @@ public:
         // 25000 rounds is just under 0.1 seconds on a 1.86 GHz Pentium M
         // ie slightly lower than the lowest hardware we need bother supporting
         nDeriveIterations = 25000;
-        nDerivationMethod = 1;
+        nDerivationMethod = 0;
         vchOtherDerivationParameters = std::vector<unsigned char>(0);
     }
 };


### PR DESCRIPTION
Решает проблему https://github.com/novacoin-project/novacoin/issues/146
Чтобы точнее понять, посмотрите функцию bool CCrypter::SetKeyFromPassphrase в файле /src/crypter.cpp
