### PR TITLE
починка бага: метка предыдущего адреса сохранялась для адреса без метки

### DIFF
--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -59,10 +59,8 @@ void SendCoinsEntry::on_payTo_textChanged(const QString &address)
 {
     if(!model)
         return;
-    // Fill in label from address book, if address has an associated label
-    QString associatedLabel = model->getAddressTableModel()->labelForAddress(address);
-    if(!associatedLabel.isEmpty())
-        ui->addAsLabel->setText(associatedLabel);
+    // Fill in label from address book
+    ui->addAsLabel->setText(model->getAddressTableModel()->labelForAddress(address));
 }
 
 void SendCoinsEntry::setModel(WalletModel *model)


### PR DESCRIPTION
Описание бага:
1)Откройте novacoin-qt
2)Перейдите во вкладку "Отправка монет"
3)Нажмите "Выберите из адресной книги" напротив получателя
4)Выберите адрес с меткой
5)Опять нажмите "Выберите из адресной книги" напротив этого же получателя
6)Выберите адрес без метки
7)Метка предыдущего адреса останется для адреса без метки.