### PR TITLE
устранил "warning : ignoring <defaultcodec> element"

### DIFF
--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="en">
-<defaultcodec>UTF-8</defaultcodec>
+<TS version="2.1" language="en">
 <context>
     <name>AboutDialog</name>
     <message>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="ru">
-<defaultcodec>UTF-8</defaultcodec>
+<TS version="2.1" language="ru">
   <context>
     <name>MultisigAddressEntry</name>
     <message>


### PR DESCRIPTION
Теперь при вызове qmake (Qt5) не будет выдаваться:
warning : ignoring *<*defaultcodec*>* element

Совместимость с Qt 4.8.6 не пострадала от удаления *<*defaultcodec*>*UTF-8*<*/defaultcodec*>*.