### PR TITLE
Окно параметров командной строки может менять размер и появилась кнопка закрыть("крестик")

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -462,6 +462,10 @@ HelpMessageBox::HelpMessageBox(QWidget *parent) :
     // setMinimumWidth is ignored for QMessageBox so put in non-breaking spaces to make it wider.
     setText(header + QString(QChar(0x2003)).repeated(50));
     setDetailedText(coreOptions + "\n" + uiOptions);
+    //addButton("OK", QMessageBox::RejectRole); //кнопка OK будет справа от кнопки "Скрыть подробности"
+    addButton("OK", QMessageBox::NoRole);       //кнопка OK будет слева от кнопки "Скрыть подробности"
+    setMouseTracking(true);
+    setSizeGripEnabled(true);   
 }
 
 void HelpMessageBox::printToConsole()

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -4,6 +4,9 @@
 #include <QString>
 #include <QObject>
 #include <QMessageBox>
+#include <QWidget>
+#include <QEvent>
+#include <QTextEdit>
 
 QT_BEGIN_NAMESPACE
 class QFont;
@@ -114,6 +117,23 @@ namespace GUIUtil
         QString header;
         QString coreOptions;
         QString uiOptions;
+
+        virtual bool event(QEvent *e) 
+        {
+            bool res = QMessageBox::event(e);
+            switch (e->type()) 
+            {
+                case QEvent::MouseMove:
+                case QEvent::MouseButtonPress:
+                    setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
+                    if (QWidget *textEdit = findChild<QTextEdit *>())
+                    {
+                        textEdit->setMaximumHeight(QWIDGETSIZE_MAX);
+                    }
+            }
+
+            return res;
+        }
     };
     /* Convert seconds into a QString with days, hours, mins, secs */
     QString formatDurationStr(int secs);


### PR DESCRIPTION
Чем сохранять файлы в кодировке UTF-8 в Windows? По умолчанию сохраняет как ANSI, поэтому русские коментарии не отображаются. Если сохранять "блокнотом" как UTF-8, то меняет первую строчку(добавляет первым символом(В ANSI кодировки) я╗┐(невидимый когда открывается в UTF-8 кодировке)). А чем сохранять, чтобы текст сохранялся в UTF-8 и не менялась первая строчка?
Пока использую такое решение:
1)Сохраняю блокнотом в UTF-8
2)Открываю файл встроенным в Far Manager редактором  и удаляю первый символ