### PR TITLE
устранил некоторые предупреждения компилятора

### DIFF
--- a/src/allocators.h
+++ b/src/allocators.h
@@ -143,7 +143,7 @@ public:
     bool Lock(const void *addr, size_t len)
     {
 #ifdef WIN32
-        return VirtualLock(const_cast<void*>(addr), len);
+        return VirtualLock(const_cast<void*>(addr), len) != 0;
 #else
         return mlock(addr, len) == 0;
 #endif
@@ -154,7 +154,7 @@ public:
     bool Unlock(const void *addr, size_t len)
     {
 #ifdef WIN32
-        return VirtualUnlock(const_cast<void*>(addr), len);
+        return VirtualUnlock(const_cast<void*>(addr), len) != 0;
 #else
         return munlock(addr, len) == 0;
 #endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -784,6 +784,7 @@ bool AppInit2()
                     break;
                 }
             } catch(std::exception &e) {
+                (void)e;
                 strLoadError = _("Error opening block database");
                 break;
             }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -735,17 +735,6 @@ void BitcoinGUI::updateMining()
         labelMiningIcon->setToolTip(tr("No suitable inputs were found"));
 }
 
-void BitcoinGUI::error(const QString &title, const QString &message, bool modal)
-{
-    // Report errors from network/worker thread
-    if(modal)
-    {
-        QMessageBox::critical(this, title, message, QMessageBox::Ok, QMessageBox::Ok);
-    } else {
-        notificator->notify(Notificator::Critical, title, message);
-    }
-}
-
 void BitcoinGUI::message(const QString &title, const QString &message, unsigned int style, const QString &detail)
 {
     QString strTitle = tr("NovaCoin") + " - ";
@@ -1116,7 +1105,7 @@ void BitcoinGUI::dumpWallet()
     QString filename = QFileDialog::getSaveFileName(this, tr("Dump Wallet"), saveDir, tr("Wallet dump (*.txt)"));
     if(!filename.isEmpty()) {
         if(!walletModel->dumpWallet(filename)) {
-            error(tr("Dump failed"),
+            message(tr("Dump failed"),
                          tr("An error happened while trying to save the keys to your location.\n"
                             "Keys were not saved.")
                       ,CClientUIInterface::MSG_ERROR);
@@ -1149,7 +1138,7 @@ void BitcoinGUI::importWallet()
     QString filename = QFileDialog::getOpenFileName(this, tr("Import Wallet"), openDir, tr("Wallet dump (*.txt)"));
     if(!filename.isEmpty()) {
         if(!walletModel->importWallet(filename)) {
-            error(tr("Import Failed"),
+            message(tr("Import Failed"),
                          tr("An error happened while trying to import the keys.\n"
                             "Some or all keys from:\n %1,\n were not imported into your wallet.")
                          .arg(filename)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -138,7 +138,6 @@ public slots:
     void setEncryptionStatus(int status);
 
     /** Notify the user of an error in the network or transaction handling code. */
-    void error(const QString &title, const QString &message, bool modal);
     void message(const QString &title, const QString &message, unsigned int style, const QString &detail=QString());
 
     /** Asks the user whether to pay the transaction fee or to cancel the transaction.

--- a/src/qt/multisigdialog.cpp
+++ b/src/qt/multisigdialog.cpp
@@ -25,10 +25,6 @@
 #include "txdb-bdb.h"
 #endif
 
-#ifdef _MSC_VER
-#pragma warning( disable : 4101)
-#endif
-
 MultisigDialog::MultisigDialog(QWidget *parent) : QWidget(parent), ui(new Ui::MultisigDialog), model(0)
 {
     ui->setupUi(this);
@@ -353,6 +349,7 @@ void MultisigDialog::on_transaction_textChanged()
     }
     catch(std::exception &e)
     {
+        (void)e;
         return;
     }
 
@@ -423,6 +420,7 @@ void MultisigDialog::on_signTransactionButton_clicked()
     }
     catch(std::exception &e)
     {
+        (void)e;
         return;
     }
     CTransaction mergedTx(tx);
@@ -542,6 +540,7 @@ void MultisigDialog::on_sendTransactionButton_clicked()
     }
     catch(std::exception &e)
     {
+        (void)e;
         return;
     }
     uint256 txHash = tx.GetHash();

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -158,6 +158,7 @@ bool OptionsModel::Upgrade()
     }
     catch (std::ios_base::failure &e)
     {
+        (void)e;
         // 0.6.0rc1 saved this as a CService, which causes failure when parsing as a CAddress
         CService addrProxy, addrTor;
         if (walletdb.ReadSetting("addrProxy", addrProxy))

--- a/src/txdb-leveldb.h
+++ b/src/txdb-leveldb.h
@@ -92,6 +92,7 @@ protected:
             ssValue >> value;
         }
         catch (std::exception &e) {
+            (void)e;
             return false;
         }
         return true;


### PR DESCRIPTION
Так же удалил BitcoinGUI::error, так как весь функционал этой функции уже есть в BitcoinGUI::message, к тому же при вызове BitcoinGUI::error использовались параметры BitcoinGUI::message ( CClientUIInterface::MSG_ERROR имеет тип int, а не bool требуемый BitcoinGUI::error)

Осталось 2 предупреждения, пока не знаю как их исправить:
![warning](http://i61.tinypic.com/bewx2h.jpg)