### PR TITLE
вернул BitcoinGUI::error

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1218,3 +1218,14 @@ void BitcoinGUI::toggleHidden()
 {
     showNormalIfMinimized(true);
 }
+
+void BitcoinGUI::error(const QString &title, const QString &message, bool modal)
+{
+    // Report errors from network/worker thread
+    if(modal)
+    {
+        QMessageBox::critical(this, title, message, QMessageBox::Ok, QMessageBox::Ok);
+    } else {
+        notificator->notify(Notificator::Critical, title, message);
+    }
+}

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -138,6 +138,7 @@ public slots:
     void setEncryptionStatus(int status);
 
     /** Notify the user of an error in the network or transaction handling code. */
+    void error(const QString &title, const QString &message, bool modal);
     void message(const QString &title, const QString &message, unsigned int style, const QString &detail=QString());
 
     /** Asks the user whether to pay the transaction fee or to cancel the transaction.


### PR DESCRIPTION
https://github.com/novacoin-project/novacoin/pull/160#issuecomment-74277788
**0xDEADFACE:**
>```
QObject::connect: No such slot BitcoinGUI::error(QString,QString,bool)
QObject::connect: No such slot BitcoinGUI::error(QString,QString,bool)
```
При запуске.

Вернул назад.