### PR TITLE
Обновил строки для перевода

### DIFF
--- a/src/qt/bitcoinstrings.cpp
+++ b/src/qt/bitcoinstrings.cpp
@@ -172,4 +172,13 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Wallet needed to be rewritten: restart NovaCo
 QT_TRANSLATE_NOOP("bitcoin-core", "Warning: Disk space is low!"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Warning: This version is obsolete, upgrade required!"),
 QT_TRANSLATE_NOOP("bitcoin-core", "wallet.dat corrupt, salvage failed"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Specify wallet file (within data directory)"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Use in-memory logging for block index database (default: 1)"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Find peers using DNS lookup (default: 1)"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Sync checkpoints policy (default: strict)"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Require a confirmations for change (default: 0)"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Enforce transaction scripts to use canonical PUSH operators (default: 1)"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Set the number of script verification threads (1-16, 0=auto, default: 0)"),
+QT_TRANSLATE_NOOP("bitcoin-core", "When creating transactions, ignore inputs with value less than this (default: %s)"),
 };

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -315,7 +315,7 @@ Copyright © 2012-2015 The NovaCoin developers</translation>
     </message>
     <message>
         <location filename="../bitcoingui.cpp" line="93"/>
-        <location filename="../bitcoingui.cpp" line="751"/>
+        <location filename="../bitcoingui.cpp" line="740"/>
         <source>NovaCoin</source>
         <translation>NovaCoin</translation>
     </message>
@@ -706,42 +706,42 @@ Copyright © 2012-2015 The NovaCoin developers</translation>
         <translation>No suitable inputs were found</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="760"/>
+        <location filename="../bitcoingui.cpp" line="749"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="763"/>
+        <location filename="../bitcoingui.cpp" line="752"/>
         <source>Warning</source>
         <translation>Warning</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="766"/>
+        <location filename="../bitcoingui.cpp" line="755"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="838"/>
+        <location filename="../bitcoingui.cpp" line="827"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="843"/>
+        <location filename="../bitcoingui.cpp" line="832"/>
         <source>Confirm transaction fee</source>
         <translation>Confirm transaction fee</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="870"/>
+        <location filename="../bitcoingui.cpp" line="859"/>
         <source>Sent transaction</source>
         <translation>Sent transaction</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="871"/>
+        <location filename="../bitcoingui.cpp" line="860"/>
         <source>Incoming transaction</source>
         <translation>Incoming transaction</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="872"/>
+        <location filename="../bitcoingui.cpp" line="861"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -754,94 +754,94 @@ Address: %4
 </translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="989"/>
-        <location filename="../bitcoingui.cpp" line="1004"/>
+        <location filename="../bitcoingui.cpp" line="978"/>
+        <location filename="../bitcoingui.cpp" line="993"/>
         <source>URI handling</source>
         <translation>URI handling</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="989"/>
-        <location filename="../bitcoingui.cpp" line="1004"/>
+        <location filename="../bitcoingui.cpp" line="978"/>
+        <location filename="../bitcoingui.cpp" line="993"/>
         <source>URI can not be parsed! This can be caused by an invalid NovaCoin address or malformed URI parameters.</source>
         <translation>URI can not be parsed! This can be caused by an invalid NovaCoin address or malformed URI parameters.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1023"/>
+        <location filename="../bitcoingui.cpp" line="1012"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1042"/>
+        <location filename="../bitcoingui.cpp" line="1031"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1091"/>
+        <location filename="../bitcoingui.cpp" line="1080"/>
         <source>Backup Wallet</source>
         <translation>Backup Wallet</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1091"/>
+        <location filename="../bitcoingui.cpp" line="1080"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Wallet Data (*.dat)</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1094"/>
+        <location filename="../bitcoingui.cpp" line="1083"/>
         <source>Backup Failed</source>
         <translation>Backup Failed</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1094"/>
+        <location filename="../bitcoingui.cpp" line="1083"/>
         <source>There was an error trying to save the wallet data to the new location.</source>
         <translation>There was an error trying to save the wallet data to the new location.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1116"/>
+        <location filename="../bitcoingui.cpp" line="1105"/>
         <source>Dump Wallet</source>
         <translation>There was an error trying to save the wallet data to the new location.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1116"/>
-        <location filename="../bitcoingui.cpp" line="1149"/>
+        <location filename="../bitcoingui.cpp" line="1105"/>
+        <location filename="../bitcoingui.cpp" line="1138"/>
         <source>Wallet dump (*.txt)</source>
         <translation>Wallet dump (*.txt)</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1119"/>
+        <location filename="../bitcoingui.cpp" line="1108"/>
         <source>Dump failed</source>
         <translation>Dump failed</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1120"/>
+        <location filename="../bitcoingui.cpp" line="1109"/>
         <source>An error happened while trying to save the keys to your location.
 Keys were not saved.</source>
         <translation>An error happened while trying to save the keys to your location.
 Keys were not saved.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1125"/>
+        <location filename="../bitcoingui.cpp" line="1114"/>
         <source>Dump successful</source>
         <translation>Dump successful</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1126"/>
+        <location filename="../bitcoingui.cpp" line="1115"/>
         <source>Keys were saved to this file:
 %2</source>
         <translation>Keys were saved to this file:
 %2</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1149"/>
+        <location filename="../bitcoingui.cpp" line="1138"/>
         <source>Import Wallet</source>
         <translation>Import Wallet</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1152"/>
+        <location filename="../bitcoingui.cpp" line="1141"/>
         <source>Import Failed</source>
         <translation>Import Failed</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1153"/>
+        <location filename="../bitcoingui.cpp" line="1142"/>
         <source>An error happened while trying to import the keys.
 Some or all keys from:
  %1,
@@ -852,12 +852,12 @@ Some or all keys from:
  were not imported into your wallet.</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1159"/>
+        <location filename="../bitcoingui.cpp" line="1148"/>
         <source>Import Successful</source>
         <translation>Import Successful</translation>
     </message>
     <message>
-        <location filename="../bitcoingui.cpp" line="1160"/>
+        <location filename="../bitcoingui.cpp" line="1149"/>
         <source>All keys from:
  %1,
  were imported into your wallet.</source>
@@ -1740,62 +1740,62 @@ This label turns red, if the priority is smaller than &quot;medium&quot;.
         <translation>Send transaction</translation>
     </message>
     <message>
-        <location filename="../multisigdialog.cpp" line="174"/>
-        <location filename="../multisigdialog.cpp" line="180"/>
-        <location filename="../multisigdialog.cpp" line="186"/>
-        <location filename="../multisigdialog.cpp" line="194"/>
+        <location filename="../multisigdialog.cpp" line="170"/>
+        <location filename="../multisigdialog.cpp" line="176"/>
+        <location filename="../multisigdialog.cpp" line="182"/>
+        <location filename="../multisigdialog.cpp" line="190"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../multisigdialog.cpp" line="174"/>
+        <location filename="../multisigdialog.cpp" line="170"/>
         <source>Number of addresses involved in the address creation &gt; %1
 Reduce the number</source>
         <translation>Number of addresses involved in the address creation &gt; %1
 Reduce the number</translation>
     </message>
     <message>
-        <location filename="../multisigdialog.cpp" line="180"/>
+        <location filename="../multisigdialog.cpp" line="176"/>
         <source>Number of required signatures is 0
 Number of required signatures must be between 1 and number of keys involved in the creation of address.</source>
         <translation>Number of required signatures is 0
 Number of required signatures must be between 1 and number of keys involved in the creation of address.</translation>
     </message>
     <message>
-        <location filename="../multisigdialog.cpp" line="186"/>
+        <location filename="../multisigdialog.cpp" line="182"/>
         <source>Number of required signatures &gt; Number of keys involved in the creation of address.</source>
         <translation>Number of required signatures &gt; Number of keys involved in the creation of address.</translation>
     </message>
     <message>
-        <location filename="../multisigdialog.cpp" line="194"/>
+        <location filename="../multisigdialog.cpp" line="190"/>
         <source>Redeem script exceeds size limit: %1 &gt; %2
 Reduce the number of addresses involved in the address creation.</source>
         <translation>Redeem script exceeds size limit: %1 &gt; %2
 Reduce the number of addresses involved in the address creation.</translation>
     </message>
     <message>
-        <location filename="../multisigdialog.cpp" line="498"/>
+        <location filename="../multisigdialog.cpp" line="496"/>
         <source>Transaction signature is complete</source>
         <translation>Transaction signature is complete</translation>
     </message>
     <message>
-        <location filename="../multisigdialog.cpp" line="503"/>
+        <location filename="../multisigdialog.cpp" line="501"/>
         <source>Transaction is NOT completely signed</source>
         <translation>Transaction is NOT completely signed</translation>
     </message>
     <message>
-        <location filename="../multisigdialog.cpp" line="524"/>
-        <location filename="../multisigdialog.cpp" line="530"/>
+        <location filename="../multisigdialog.cpp" line="522"/>
+        <location filename="../multisigdialog.cpp" line="528"/>
         <source>Confirm send transaction</source>
         <translation>Confirm send transaction</translation>
     </message>
     <message>
-        <location filename="../multisigdialog.cpp" line="524"/>
+        <location filename="../multisigdialog.cpp" line="522"/>
         <source>The fee of the transaction (%1 NVC) is smaller than the expected fee (%2 NVC). Do you want to send the transaction anyway?</source>
         <translation>The fee of the transaction (%1 NVC) is smaller than the expected fee (%2 NVC). Do you want to send the transaction anyway?</translation>
     </message>
     <message>
-        <location filename="../multisigdialog.cpp" line="530"/>
+        <location filename="../multisigdialog.cpp" line="528"/>
         <source>The fee of the transaction (%1 NVC) is bigger than the expected fee (%2 NVC). Do you want to send the transaction anyway?</source>
         <translation>The fee of the transaction (%1 NVC) is bigger than the expected fee (%2 NVC). Do you want to send the transaction anyway?</translation>
     </message>
@@ -2217,22 +2217,22 @@ Reduce the number of addresses involved in the address creation.</translation>
         <translation>Amount</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="499"/>
+        <location filename="../guiutil.cpp" line="498"/>
         <source>%1 d</source>
         <translation>%1 d</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="501"/>
+        <location filename="../guiutil.cpp" line="500"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="503"/>
+        <location filename="../guiutil.cpp" line="502"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="505"/>
+        <location filename="../guiutil.cpp" line="504"/>
         <source>%1 s</source>
         <translation>%1 s</translation>
     </message>
@@ -4166,6 +4166,51 @@ If the file does not exist, create it with owner-readable-only file permissions.
         <location filename="../bitcoinstrings.cpp" line="174"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat corrupt, salvage failed</translation>
+    </message>
+    <message>
+        <location filename="../bitcoinstrings.cpp" line="175"/>
+        <source>Specify wallet file (within data directory)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../bitcoinstrings.cpp" line="176"/>
+        <source>Use in-memory logging for block index database (default: 1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../bitcoinstrings.cpp" line="177"/>
+        <source>Find peers using DNS lookup (default: 1)</source>
+        <translation type="unfinished">Find peers using DNS lookup (default: 0) {1)?}</translation>
+    </message>
+    <message>
+        <location filename="../bitcoinstrings.cpp" line="178"/>
+        <source>Sync checkpoints policy (default: strict)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../bitcoinstrings.cpp" line="179"/>
+        <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../bitcoinstrings.cpp" line="180"/>
+        <source>Require a confirmations for change (default: 0)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../bitcoinstrings.cpp" line="181"/>
+        <source>Enforce transaction scripts to use canonical PUSH operators (default: 1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../bitcoinstrings.cpp" line="182"/>
+        <source>Set the number of script verification threads (1-16, 0=auto, default: 0)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../bitcoinstrings.cpp" line="183"/>
+        <source>When creating transactions, ignore inputs with value less than this (default: %s)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -425,7 +425,7 @@ Copyright © 2012-2015 The NovaCoin developers</source>
         <translation>&amp;Выгрузка ключей...</translation>
     </message>
     <message>
-        <location line="+801"/>
+        <location line="+790"/>
         <source>Dump Wallet</source>
         <translation>Выгрузка ключей</translation>
     </message>
@@ -513,7 +513,7 @@ Some or all keys from:
         <translation>Файл с ключами (*.txt)</translation>
     </message>
     <message>
-        <location line="-832"/>
+        <location line="-821"/>
         <source>&amp;Import Wallet...</source>
         <translation>&amp;Импорт ключей...</translation>
     </message>
@@ -613,12 +613,12 @@ Some or all keys from:
     </message>
     <message>
         <location line="-230"/>
-        <location line="+658"/>
+        <location line="+647"/>
         <source>NovaCoin</source>
         <translation>NovaCoin</translation>
     </message>
     <message>
-        <location line="-658"/>
+        <location line="-647"/>
         <source>Wallet</source>
         <translation>Бумажник</translation>
     </message>
@@ -760,12 +760,12 @@ Some or all keys from:
         <translation>Нет подходящих транзакций</translation>
     </message>
     <message>
-        <location line="+424"/>
+        <location line="+413"/>
         <source>Import Successful</source>
         <translation>Импорт завершен</translation>
     </message>
     <message>
-        <location line="-829"/>
+        <location line="-818"/>
         <source>Unlo&amp;ck wallet</source>
         <translation>Разб&amp;локировать бумажник</translation>
     </message>
@@ -800,7 +800,7 @@ Some or all keys from:
         <translation>&amp;Безопасность</translation>
     </message>
     <message>
-        <location line="+454"/>
+        <location line="+443"/>
         <source>This transaction is over the size limit.  You can still send it for a fee of %1, which goes to the nodes that process your transaction and helps to support the network.  Do you want to pay the fee?</source>
         <translation>Данная транзакция превышает предельно допустимый размер.  Но Вы можете всё равно совершить её, добавив комиссию в %1, которая отправится тем узлам, которые обработают Вашу транзакцию, и поможет поддержать сеть.  Вы хотите добавить комиссию?</translation>
     </message>
@@ -1578,7 +1578,7 @@ This label turns red, if the priority is smaller than &quot;medium&quot;.
 <context>
     <name>MultisigDialog</name>
     <message>
-        <location filename="../multisigdialog.cpp" line="+174"/>
+        <location filename="../multisigdialog.cpp" line="+170"/>
         <location line="+6"/>
         <location line="+6"/>
         <location line="+8"/>
@@ -1610,7 +1610,7 @@ Reduce the number of addresses involved in the address creation.</source>
 Уменьшите число адресов, участвующих в создании адреса с мультиподписью</translation>
     </message>
     <message>
-        <location line="+304"/>
+        <location line="+306"/>
         <source>Transaction signature is complete</source>
         <translation>Подписание транзакции завершено</translation>
     </message>
@@ -2232,7 +2232,7 @@ Reduce the number of addresses involved in the address creation.</source>
         <translation>от %1 до %2</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+41"/>
+        <location filename="../guiutil.cpp" line="+40"/>
         <source>%1 d</source>
         <translation>%1 д</translation>
     </message>
@@ -2690,10 +2690,6 @@ Reduce the number of addresses involved in the address creation.</source>
         <location line="+22"/>
         <source>Balance:</source>
         <translation>Баланс:</translation>
-    </message>
-    <message>
-        <source>123.456 BTC</source>
-        <translation type="vanished">123.456 BTC</translation>
     </message>
     <message>
         <location line="+41"/>
@@ -3599,11 +3595,12 @@ Reduce the number of addresses involved in the address creation.</source>
         <translation>Указать pid-файл (по умолчанию: novacoin.pid)</translation>
     </message>
     <message>
+        <location line="+22"/>
         <source>Specify wallet file (within data directory)</source>
-        <translation type="vanished">Указать файл кошелька (в пределах DATA директории)</translation>
+        <translation>Указать файл кошелька (в пределах DATA директории)</translation>
     </message>
     <message>
-        <location line="-1"/>
+        <location line="-23"/>
         <source>Specify data directory</source>
         <translation>Укажите каталог данных</translation>
     </message>
@@ -3668,11 +3665,12 @@ Reduce the number of addresses involved in the address creation.</source>
         <translation>Отключить базы данных блоков и адресов. Увеличивает время завершения работы (по умолчанию: 0)</translation>
     </message>
     <message>
+        <location line="+147"/>
         <source>Use in-memory logging for block index database (default: 1)</source>
-        <translation type="vanished">Использовать ведение журнала в памяти для индекса базы данных блоков (по умолчанию: 1)</translation>
+        <translation>Использовать ведение журнала в памяти для индекса базы данных блоков (по умолчанию: 1)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-145"/>
         <source>Error initializing database environment %s! To recover, BACKUP THAT DIRECTORY, then remove everything from it except for wallet.dat.</source>
         <translation>Ошибка инициализации окружения БД %s! Для восстановления СДЕЛАЙТЕ РЕЗЕРВНУЮ КОПИЮ этой директории, затем удалите из нее все, кроме wallet.dat.</translation>
     </message>
@@ -3707,15 +3705,17 @@ Reduce the number of addresses involved in the address creation.</source>
         <translation>Попытка восстановления ключей из поврежденного wallet.dat</translation>
     </message>
     <message>
+        <location line="+98"/>
         <source>Find peers using DNS lookup (default: 1)</source>
-        <translation type="vanished">Искать узлы с помощью DNS (по умолчанию: 1)</translation>
+        <translation>Искать узлы с помощью DNS (по умолчанию: 1)</translation>
     </message>
     <message>
+        <location line="+1"/>
         <source>Sync checkpoints policy (default: strict)</source>
-        <translation type="vanished">Политика синхронизированных меток (по умолчанию: strict)</translation>
+        <translation>Политика синхронизированных меток (по умолчанию: strict)</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="-71"/>
         <source>Importing blockchain data file.</source>
         <translation>Импортируется файл цепи блоков.</translation>
     </message>
@@ -3953,24 +3953,27 @@ Reduce the number of addresses involved in the address creation.</source>
         <translation>Выполнить команду, когда появляется новый блок (%s в команде заменяется на хэш блока)</translation>
     </message>
     <message>
+        <location line="+136"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
-        <translation type="vanished">Выполнить команду, когда получена новая транзакция (%s в команде заменяется на ID транзакции)</translation>
+        <translation>Выполнить команду, когда получена новая транзакция (%s в команде заменяется на ID транзакции)</translation>
     </message>
     <message>
-        <location line="+119"/>
+        <location line="-17"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Обновить бумажник до последнего формата</translation>
     </message>
     <message>
+        <location line="+18"/>
         <source>Require a confirmations for change (default: 0)</source>
-        <translation type="vanished">Требовать подтверждения для сдачи (по умолчанию: 0)</translation>
+        <translation>Требовать подтверждения для сдачи (по умолчанию: 0)</translation>
     </message>
     <message>
+        <location line="+1"/>
         <source>Enforce transaction scripts to use canonical PUSH operators (default: 1)</source>
-        <translation type="vanished">Требовать от скриптов использования стандартных PUSH операторов (по умолчанию: 1)</translation>
+        <translation>Требовать от скриптов использования стандартных PUSH операторов (по умолчанию: 1)</translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="-35"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Установить размер запаса ключей в &lt;n&gt; (по умолчанию: 100)</translation>
     </message>
@@ -3990,11 +3993,12 @@ Reduce the number of addresses involved in the address creation.</source>
         <translation>Насколько тщательно проверять блоки (0-6, по умолчанию: 1)</translation>
     </message>
     <message>
+        <location line="+76"/>
         <source>Set the number of script verification threads (1-16, 0=auto, default: 0)</source>
-        <translation type="vanished">Установить число потоков проверки скрипта (1-16, 0= автоматически, по умолчанию: 0)</translation>
+        <translation>Установить число потоков проверки скрипта (1-16, 0= автоматически, по умолчанию: 0)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="-73"/>
         <source>Imports blocks from external blk000?.dat file</source>
         <translation>Импортировать блоки из внешнего файла blk000?.dat</translation>
     </message>
@@ -4154,11 +4158,12 @@ Reduce the number of addresses involved in the address creation.</source>
         <translation>Комиссия на килобайт, добавляемая к вашим транзакциям</translation>
     </message>
     <message>
+        <location line="+82"/>
         <source>When creating transactions, ignore inputs with value less than this (default: %s)</source>
-        <translation type="vanished">При создании транзакций игнорировать входы с суммой ниже указанной (по умолчанию: %s)</translation>
+        <translation>При создании транзакций игнорировать входы с суммой ниже указанной (по умолчанию: %s)</translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="-63"/>
         <source>Loading wallet...</source>
         <translation>Загрузка бумажника...</translation>
     </message>


### PR DESCRIPTION
Добавил строки для перевода в bitcoinstrings.cpp, которые lupdate не нашёл и пометил пропавшими(type="vanished"). Видимо потому что эти строки мы добавляли вручную(они есть в init.cpp, без добавления в bitcoinstrings.cpp они остаются непереведенными)...
Обновился до текущего мастера и сделал повторно lupdate.(из-за этого обновились часть номеров строк)
Так же удалил из перевода:
*<*message*>*
        *<*source*>*123.456 BTC*<*/source*>*
        *<*translation type="vanished"*>*123.456 BTC*<*/translation*>*
*<*/message*>*
В форме у нас 123.456 NVC, вариант с BTC оставался только в файле переводов(причём помеченный как vanished)
![form](http://i.imgur.com/7ftd0m4.jpg)
Надеюсь больше ничего не забыл.