### PR TITLE
производительность Qt

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -117,9 +117,6 @@ void WalletModel::checkBalanceChanged()
 
 void WalletModel::updateTransaction(const QString &hash, int status)
 {
-    if(transactionTableModel)
-        transactionTableModel->updateTransaction(hash, status);
-
     // Balance and number of transactions might have changed
     checkBalanceChanged();
 
@@ -128,6 +125,9 @@ void WalletModel::updateTransaction(const QString &hash, int status)
     {
         cachedNumTransactions = newNumTransactions;
         emit numTransactionsChanged(newNumTransactions);
+
+        if(transactionTableModel)
+            transactionTableModel->updateTransaction(hash, status);
     }
 }
 


### PR DESCRIPTION
не пытаемся обновить нашу вкладку "транзакции", если транзакция
предназначалась не нам. Очень существенно повышает отзывчивость GUI при
синхронизации.