### PR TITLE
возвращение совместимости со старым boost

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1157,7 +1157,11 @@ void createConf()
     srand(time(NULL));
 
     ofstream pConf;
+#if BOOST_FILESYSTEM_VERSION >= 3
     pConf.open(GetConfigFile().generic_string().c_str());
+#else
+    pConf.open(GetConfigFile().string().c_str());
+#endif
     pConf << "rpcuser=user\nrpcpassword="
             + randomStrGen(15)
             + "\nrpcport=8344"


### PR DESCRIPTION
@CryptoManiac:
>Поломалась совместимость со старым бустом (1.48):
>
```
util.cpp: In function 'void createConf()':
util.cpp:1160: error: 'struct boost::filesystem::path' has no member named 'generic_string'
```
В принципе, несущественно.
