### PR TITLE
Replace non-threadsafe gmtime and setlocale

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -361,15 +361,7 @@ string HTTPPost(const string& strMsg, const map<string,string>& mapRequestHeader
 
 string rfc1123Time()
 {
-    char buffer[64];
-    time_t now;
-    time(&now);
-    struct tm* now_gmt = gmtime(&now);
-    string locale(setlocale(LC_TIME, NULL));
-    setlocale(LC_TIME, "C"); // we want POSIX (aka "C") weekday/month strings
-    strftime(buffer, sizeof(buffer), "%a, %d %b %Y %H:%M:%S +0000", now_gmt);
-    setlocale(LC_TIME, locale.c_str());
-    return string(buffer);
+    return DateTimeStrFormat("%a, %d %b %Y %H:%M:%S +0000", GetTime());
 }
 
 static string HTTPReply(int nStatus, const string& strMsg, bool keepalive)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1464,3 +1464,13 @@ bool NewThread(void(*pfn)(void*), void* parg)
     }
     return true;
 }
+
+std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime)
+{
+    // std::locale takes ownership of the pointer
+    std::locale loc(std::locale::classic(), new boost::posix_time::time_facet(pszFormat));
+    std::stringstream ss;
+    ss.imbue(loc);
+    ss << boost::posix_time::from_time_t(nTime);
+    return ss.str();
+}

--- a/src/util.h
+++ b/src/util.h
@@ -351,14 +351,7 @@ inline int64_t GetTimeMillis()
             boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_milliseconds();
 }
 
-inline std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime)
-{
-    time_t n = nTime;
-    struct tm* ptmTime = gmtime(&n);
-    char pszTime[200];
-    strftime(pszTime, sizeof(pszTime), pszFormat, ptmTime);
-    return pszTime;
-}
+std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime);
 
 static const std::string strTimestampFormat = "%Y-%m-%d %H:%M:%S UTC";
 inline std::string DateTimeStrFormat(int64_t nTime)


### PR DESCRIPTION
Фактически перенос этого коммита https://github.com/laanwj/bitcoin/commit/3e8ac6af9a993e262d1160fb2e6e1e1f1d5d19f2
Как следствие сокращает количество warning-ов при компиляции в msvc. В плане тестов: данная сборка живёт более суток на трёх нодах (ubuntu-arm gcc и win32 msvc сборки), сгенерировано несколько валидных pos блоков в основной сети.