### PR TITLE
add PoS and PoW difficulty to tooltip

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -622,6 +622,9 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
         progressBar->setVisible(false);
     }
 
+    tooltip = tr("Current PoW difficulty is %1.").arg(clientModel->getDifficulty(false)) + QString("<br>") + tooltip;
+    tooltip = tr("Current PoS difficulty is %1.").arg(clientModel->getDifficulty(true)) + QString("<br>") + tooltip;
+
     QDateTime lastBlockDate = clientModel->getLastBlockDate();
     int secs = lastBlockDate.secsTo(QDateTime::currentDateTime());
     QString text;


### PR DESCRIPTION
По просьбам: https://bitcointalk.org/index.php?topic=704756.msg12024413#msg12024413
Правда добавил в всплывающую подсказку о синхронизации, так как и PoW и PoS. Но можно переделать и добавить в всплывающую подсказку о состоянии майнера...
![difficulty](http://i.imgur.com/XmMceXA.png)