### PR TITLE
Add raise() for MultisigPage and for RpcConsole

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -204,6 +204,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
 
     rpcConsole = new RPCConsole(0);
     connect(openRPCConsoleAction, SIGNAL(triggered()), rpcConsole, SLOT(show()));
+    connect(openRPCConsoleAction, SIGNAL(triggered()), rpcConsole, SLOT(raise()));
 
     aboutDialog = new AboutDialog(0);
     optionsDialog = new OptionsDialog(0);
@@ -933,7 +934,8 @@ void BitcoinGUI::gotoVerifyMessageTab(QString addr)
 void BitcoinGUI::gotoMultisigPage()
 {
     multisigPage->show();
-    multisigPage->setFocus();
+    multisigPage->raise();
+    multisigPage->activateWindow();
 }
 
 void BitcoinGUI::dragEnterEvent(QDragEnterEvent *event)


### PR DESCRIPTION
Отвечу для чего это нужно.
Если вызвать окно Debug window и заслонить его основной формой, то при повторном его вызове кликом из меню оно не переходит на передний план. Приходится выбирать табом или кликом из системной панели. Аналогичная ситуация с окном мультиподписи. Эту замену     multisigPage->activateWindow();
//    multisigPage->setFocus();
оставлю как якорь, тк в старом варианте почему то не всегда срабатывал фокус. Мой коммит исправляет неудобство с переводом форм на передний план.