### PR TITLE
Fix msvc c4127 warning

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1418,7 +1418,7 @@ public:
 
     // search for a given byte in the stream, and remain positioned on it
     void FindByte(char ch) {
-        while (true) {
+        for ( ; ; ) {
             if (nReadPos == nSrcPos)
                 Fill();
             if (vchBuf[nReadPos % vchBuf.size()] == ch)


### PR DESCRIPTION
Оставлю этот коммит как заметку. В коде есть масса while ( true ) и while ( 1 ) , msvc любит так
for ( ; ; ) ссылка на  https://msdn.microsoft.com/en-us/library/6t66728h%28v=vs.90%29.aspx
Будем причёсывать к единообразию?