### PR TITLE
Code cleanup (icc warning #271 trailing comma is nonstandard)

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -102,7 +102,7 @@ public:
         PUBKEY_ADDRESS = 8,
         SCRIPT_ADDRESS = 20,
         PUBKEY_ADDRESS_TEST = 111,
-        SCRIPT_ADDRESS_TEST = 196,
+        SCRIPT_ADDRESS_TEST = 196
     };
 
     bool Set(const CKeyID &id);

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -27,7 +27,7 @@ enum HTTPStatusCode
     HTTP_UNAUTHORIZED          = 401,
     HTTP_FORBIDDEN             = 403,
     HTTP_NOT_FOUND             = 404,
-    HTTP_INTERNAL_SERVER_ERROR = 500,
+    HTTP_INTERNAL_SERVER_ERROR = 500
 };
 
 // Bitcoin RPC error codes
@@ -63,7 +63,7 @@ enum RPCErrorCode
     RPC_WALLET_PASSPHRASE_INCORRECT = -14, // The wallet passphrase entered was incorrect
     RPC_WALLET_WRONG_ENC_STATE      = -15, // Command given in wrong wallet encryption state (encrypting an encrypted wallet etc.)
     RPC_WALLET_ENCRYPTION_FAILED    = -16, // Failed to encrypt the wallet
-    RPC_WALLET_ALREADY_UNLOCKED     = -17, // Wallet is already unlocked
+    RPC_WALLET_ALREADY_UNLOCKED     = -17  // Wallet is already unlocked
 };
 
 json_spirit::Object JSONRPCError(int code, const std::string& message);

--- a/src/main.h
+++ b/src/main.h
@@ -427,7 +427,7 @@ enum GetMinFee_mode
 {
     GMF_BLOCK,
     GMF_RELAY,
-    GMF_SEND,
+    GMF_SEND
 };
 
 typedef std::map<uint256, std::pair<CTxIndex, CTransaction> > MapPrevTx;
@@ -1176,7 +1176,7 @@ public:
     {
         BLOCK_PROOF_OF_STAKE = (1 << 0), // is proof-of-stake block
         BLOCK_STAKE_ENTROPY  = (1 << 1), // entropy bit for stake modifier
-        BLOCK_STAKE_MODIFIER = (1 << 2), // regenerated stake modifier
+        BLOCK_STAKE_MODIFIER = (1 << 2)  // regenerated stake modifier
     };
 
     uint64_t nStakeModifier; // hash modifier for proof-of-stake

--- a/src/net.h
+++ b/src/net.h
@@ -77,7 +77,7 @@ CAddress GetLocalAddress(const CNetAddr *paddrPeer = NULL);
 enum
 {
     MSG_TX = 1,
-    MSG_BLOCK,
+    MSG_BLOCK
 };
 
 class CRequestTracker

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -25,7 +25,7 @@ enum Network
     NET_TOR,
     NET_I2P,
 
-    NET_MAX,
+    NET_MAX
 };
 
 extern int nConnectTimeout;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -68,7 +68,7 @@ class CMessageHeader
 /** nServices flags */
 enum
 {
-    NODE_NETWORK = (1 << 0),
+    NODE_NETWORK = (1 << 0)
 };
 
 /** A CService with information about it as peer */

--- a/src/script.h
+++ b/src/script.h
@@ -36,7 +36,7 @@ enum
     SIGHASH_ALL = 1,
     SIGHASH_NONE = 2,
     SIGHASH_SINGLE = 3,
-    SIGHASH_ANYONECANPAY = 0x80,
+    SIGHASH_ANYONECANPAY = 0x80
 };
 
 /** Script verification flags */
@@ -47,7 +47,7 @@ enum
     SCRIPT_VERIFY_STRICTENC = (1U << 1), // enforce strict conformance to DER and SEC2 for signatures and pubkeys
     SCRIPT_VERIFY_LOW_S     = (1U << 2), // enforce low S values in signatures (depends on STRICTENC)
     SCRIPT_VERIFY_NOCACHE   = (1U << 3), // do not store results in signature cache (but do query it)
-    SCRIPT_VERIFY_NULLDUMMY = (1U << 4), // verify dummy stack item consumed by CHECKMULTISIG is of zero-length
+    SCRIPT_VERIFY_NULLDUMMY = (1U << 4)  // verify dummy stack item consumed by CHECKMULTISIG is of zero-length
 };
 
 // Strict verification:
@@ -79,7 +79,7 @@ enum txnouttype
     TX_PUBKEYHASH,
     TX_SCRIPTHASH,
     TX_MULTISIG,
-    TX_NULL_DATA,
+    TX_NULL_DATA
 };
 
 const char* GetTxnOutputType(txnouttype t);
@@ -228,7 +228,7 @@ enum opcodetype
     OP_PUBKEYHASH = 0xfd,
     OP_PUBKEY = 0xfe,
 
-    OP_INVALIDOPCODE = 0xff,
+    OP_INVALIDOPCODE = 0xff
 };
 
 const char* GetOpName(opcodetype opcode);

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -58,7 +58,7 @@ enum
 
 	 // modifiers
 	 SER_SKIPSIG = (1 << 16),
-	 SER_BLOCKHEADERONLY = (1 << 17),
+	 SER_BLOCKHEADERONLY = (1 << 17)
 
 };
 


### PR DESCRIPTION
Transform enum {a,b,}; to enum {a,b};