### PR TITLE
адаптация инструкции к текущей версии mxe

### DIFF
--- a/doc/crosscompiling_building Windows binary under Unix.txt
+++ b/doc/crosscompiling_building Windows binary under Unix.txt
@@ -11,17 +11,18 @@
 
 2.1) gcc
  cd /home/<ваше имя>/mxe
- make gcc zlib
+ make gcc zlib libpng
 
 Проверка того, что установка gcc прошла успешно:
 В папке /home/<ваше имя>/mxe/usr/bin должен появиться файл i686-w64-mingw32.static-gcc и i686-w64-mingw32.static-g++
 И при запуске ./i686-w64-mingw32.static-gcc -v должно выдаваться
 ......
 Thread model: win32
-gcc version 4.9.2 (GCC)
+gcc version 4.9.3 (GCC)
 
-В папке /home/<ваше имя>/mxe/usr/i686-w64-mingw32.static/lib должен быть файл:
+В папке /home/<ваше имя>/mxe/usr/i686-w64-mingw32.static/lib должны быть файлы:
 libz.a
+libpng.a
 
 2.2) Openssl
  
@@ -67,31 +68,13 @@ libdb.a
 libdb_cxx.a
 
 2.5) qrencode
--Скачайте http://download.sourceforge.net/libpng/libpng-1.6.15.tar.gz?download
--Распакуйте в домашнюю папку
--Откройте терминал
-
- export PATH=/home/<ваше имя>/mxe/usr/bin:$PATH
- cd /home/<ваше имя>/libpng-1.6.15
- ./configure --host=i686-w64-mingw32.static --disable-shared
- make
- cp .libs/libpng16.a .libs/libpng.a
-
-Проверка что libpng собралась успешно:
-в папке /home/<ваше имя>/libpng-1.6.15/.libs должен быть файл:
-libpng.a
-
 -Скачайте http://fukuchi.org/works/qrencode/qrencode-3.4.4.tar.gz
 -Распакуйте в домашнюю папку
--Откройте терминал
+-Откройте терминал:
+
  export PATH=/home/<ваше имя>/mxe/usr/bin:$PATH
  cd /home/<ваше имя>/qrencode-3.4.4
-
- LIBS="../libpng-1.6.15/.libs/libpng.a ../mxe/usr/i686-w64-mingw32.static/lib/libz.a" \
- png_CFLAGS="-I../libpng-1.6.15" \
- png_LIBS="-L../libpng-1.6.15/.libs" \
  ./configure --host=i686-w64-mingw32.static --enable-static --disable-shared --without-tools
-
  make
 
 Проверка что qrencode успешно собралась:
@@ -114,7 +97,7 @@ Qt 4
 
 -Должно появиться в ответ
 QMake version 2.01a
-Using Qt version 4.8.6 in /home/<ваше имя>/mxe/usr/i686-w64-mingw32.static/qt/lib
+Using Qt version 4.8.7 in /home/<ваше имя>/mxe/usr/i686-w64-mingw32.static/qt/lib
 
 Qt 5
 -Откройте терминал
@@ -131,7 +114,7 @@ Qt 5
 
 -Должно появиться в ответ
 QMake version 3.0
-Using Qt version 5.4.0 in /home/<ваше имя>/mxe/usr/i686-w64-mingw32.static/qt5/lib
+Using Qt version 5.5.1 in /home/<ваше имя>/mxe/usr/i686-w64-mingw32.static/qt5/lib
 
 3. Компиляция
 
@@ -150,16 +133,14 @@ CXX=$(CROSS)g++
 -Поменяйте текущие INCLUDEPATHS, LIBPATHS, LIBS на:
 
 BOOST_SUFFIX?=-mt
+BOOST_THREAD_LIB_SUFFIX?=_win32-mt
 
 INCLUDEPATHS= \
  -I"$(CURDIR)" \
- -I"/home/<ваше имя>/mxe/usr/i686-w64-mingw32.static/include" \
- -I"/home/<ваше имя>/" \
  -I"/home/<ваше имя>/db-6.0.20/build_unix" \
  
 LIBPATHS= \
  -L"$(CURDIR)/leveldb" \
- -L"/home/<ваше имя>/mxe/usr/i686-w64-mingw32.static/lib" \
  -L"/home/<ваше имя>/db-6.0.20/build_unix" \
 
 LIBS= \
@@ -168,14 +149,13 @@ LIBS= \
   -l boost_system$(BOOST_SUFFIX) \
   -l boost_filesystem$(BOOST_SUFFIX) \
   -l boost_program_options$(BOOST_SUFFIX) \
-  -l boost_thread$(BOOST_SUFFIX) \
+  -l boost_thread$(BOOST_THREAD_LIB_SUFFIX) \
   -l boost_chrono$(BOOST_SUFFIX) \
   -l db_cxx \
   -l ssl \
   -l crypto \
-  -l z
--Поменяйте LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat на 
-LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat -Wl,--large-address-aware -static
+  -l z \
+  -l pthread
 
 -Поменяйте в последних строчках makefile.mingw
 g++ -c $(CFLAGS) -o $@ $<
@@ -203,19 +183,27 @@ cd leveldb; make; cd ..
 на 
 cd leveldb; TARGET_OS=NATIVE_WINDOWS make CROSS=i686-w64-mingw32.static- libleveldb.a libmemenv.a; cd ..
 
-Ещё измените
-obj/txdb-leveldb.o: leveldb/libleveldb.lib
-на
-obj/txdb-leveldb.o: leveldb/libleveldb.a
-
 Если вы хотите использовать BerkeleyDB как базу блоков, то просто удалите строчку USE_LEVELDB:=1
+
+Измените
+clean:
+	-del /Q novacoind.exe
+	-del /Q obj\*
+	-del /Q crypto\scrypt\asm\obj\*
+
+на
+
+clean:
+	-rm novacoind.exe
+	-rm obj/*
+	-rm crypto/scrypt/asm/obj/*
 
 -Сохраните измененный файл makefile.mingw
 
 -Откройте терминал
 cd /home/<ваше имя>/novacoin/src
 export PATH=/home/<ваше имя>/mxe/usr/bin:$PATH
-make CROSS=i686-w64-mingw32.static- -f makefile.mingw
+make -j n CROSS=i686-w64-mingw32.static- -f makefile.mingw (вместо n количество ядер вашего процессора, которые вы хотите выделить под сборку)
 strip novacoind.exe
 
 
@@ -231,7 +219,7 @@ libboost_thread_win32-mt.a(thread.o): duplicate section `.rdata$_ZTVN5boost16exc
 -Откройте терминал и выполните следующие команды:
 export PATH=/home/<ваше имя>/mxe/usr/bin:$PATH
 cd /home/<ваше имя>/novacoin/src/leveldb
-TARGET_OS=NATIVE_WINDOWS make CROSS=i686-w64-mingw32.static- libleveldb.a libmemenv.a;
+TARGET_OS=NATIVE_WINDOWS make CROSS=i686-w64-mingw32.static- libleveldb.a libmemenv.a
 
 -Откройте файл /home/<ваше имя>/novacoin/novacoin-qt.pro в текстовом редакторе(при написании инструкции использовался Pluma 1.8.1)
 -Ниже 
@@ -241,12 +229,9 @@ TARGET_OS=NATIVE_WINDOWS make CROSS=i686-w64-mingw32.static- libleveldb.a libmem
 замените прописанные пути к зависимостям на
 
 BOOST_LIB_SUFFIX=-mt
-BOOST_INCLUDE_PATH=/home/<ваше имя>/mxe/usr/i686-w64-mingw32.static/include
-BOOST_LIB_PATH=/home/<ваше имя>/mxe/usr/i686-w64-mingw32.static/lib
+BOOST_THREAD_LIB_SUFFIX=_win32-mt
 BDB_INCLUDE_PATH=/home/<ваше имя>/db-6.0.20/build_unix
-BDB_LIB_PATH=//home/<ваше имя>/db-6.0.20/build_unix
-OPENSSL_INCLUDE_PATH=/home/<ваше имя>/mxe/usr/i686-w64-mingw32.static/include
-OPENSSL_LIB_PATH=/home/<ваше имя>/mxe/usr/i686-w64-mingw32.static/lib
+BDB_LIB_PATH=/home/<ваше имя>/db-6.0.20/build_unix
 QRENCODE_INCLUDE_PATH=/home/<ваше имя>/qrencode-3.4.4
 QRENCODE_LIB_PATH=/home/<ваше имя>/qrencode-3.4.4/.libs
 
@@ -270,16 +255,6 @@ win32:QMAKE_LFLAGS *= -Wl,--large-address-aware -static
 win32:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]\\lrelease.exe
 на
 win32:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
-
-Измените
-LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX
-на
-LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread_win32$$BOOST_THREAD_LIB_SUFFIX
-
-Измените
-windows:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX -Wl,-Bstatic -lpthread -Wl,-Bdynamic
-на
-windows:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX
 
 -Сохраните измененный файл novacoin-qt.pro
 -Откройте терминал и выполните следующие команды

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -150,7 +150,7 @@ novacoind.exe: $(OBJS:obj/%=obj/%)
 	g++ $(CFLAGS) $(LDFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS)
 
 clean:
-	-del /Q novacoind
+	-del /Q novacoind.exe
 	-del /Q obj\*
 	-del /Q crypto\scrypt\asm\obj\*
 


### PR DESCRIPTION
@svost заметил что novacoin не собирается по текущей инструкции, так же указал на таргет clean. Я посмотрел и увидел что mxe теперь собирает gcc вместе с pthread и внёс необходимые изменения в инструкцию.
Также немного упростил инструкцию:
-используем mxe libpng, а не скаченный самостоятельно
-используем BOOST_THREAD_LIB_SUFFIX вместо ручного изменения имени библиотеки
-добавляем инструкции к таргету clean для работоспособности в Linux
-удаляем лишние пути /home/<ваше имя>/mxe/usr/i686-w64-mingw32.static/lib и /home/<ваше имя>/mxe/usr/i686-w64-mingw32.static/lib  так как они по умолчанию есть в компиляторе.