### PR TITLE
Reorganize includes a bit.

### DIFF
--- a/src/ecies.cpp
+++ b/src/ecies.cpp
@@ -11,7 +11,6 @@
 #include "ies.h"
 #include <iostream>
 #include <vector>
-#include <openssl/ecdh.h>
 
 #define SET_ERROR(string) \
     sprintf(error, "%s %s:%d", (string), __FILE__, __LINE__)

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -6,12 +6,9 @@
 
 #include <openssl/ecdsa.h>
 #include <openssl/obj_mac.h>
-#include <openssl/ssl.h>
-#include <openssl/ecdh.h>
 
 #include "key.h"
 #include "base58.h"
-#include "ies.h"
 
 // Generate a private key from just the secret parameter
 int EC_KEY_regenerate_key(EC_KEY *eckey, BIGNUM *priv_key)

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -12,8 +12,6 @@
 #include "main.h"
 #include "net.h"
 #include "wallet.h"
-#include "script.h"
-#include "util.h"
 
 using namespace std;
 using namespace boost;


### PR DESCRIPTION
В общем без этого изменения MSVC падает при сборке key.cpp с аналогичными симптомами http://stackoverflow.com/questions/1372480/c-redefinition-header-files-winsock2-h Текущий рабочий вариант проверен на msvc, mxe и линуксовой сборке.