### PR TITLE
Minor fix: c++11 branch

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -445,7 +445,7 @@ bool AppInit2()
     // -par=0 means autodetect, but nScriptCheckThreads==0 means no concurrency
     nScriptCheckThreads = GetArgInt("-par", 0);
     if (nScriptCheckThreads == 0)
-        nScriptCheckThreads = boost::thread::hardware_concurrency();
+        nScriptCheckThreads = std::thread::hardware_concurrency();
     if (nScriptCheckThreads <= 1) 
         nScriptCheckThreads = 0;
     else if (nScriptCheckThreads > MAX_SCRIPTCHECK_THREADS)

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -429,7 +429,7 @@ bool ScanKernelForward(unsigned char *kernel, uint32_t nBits, uint32_t nInputTxT
     {
         using namespace boost;
 
-        auto nThreads = thread::hardware_concurrency();
+        auto nThreads = std::thread::hardware_concurrency();
         auto vWorkers = vector<KernelWorker>(nThreads);
         auto nPart = (SearchInterval.second - SearchInterval.first) / nThreads;
         thread_group group;

--- a/src/util.h
+++ b/src/util.h
@@ -17,6 +17,8 @@
 #include <map>
 #include <vector>
 #include <string>
+#include <chrono>
+#include <thread>
 
 #ifndef Q_MOC_RUN
 #include <boost/thread.hpp>
@@ -124,9 +126,7 @@ T* alignup(T* p)
 #define MAX_PATH            1024
 inline void Sleep(int64_t n)
 {
-    /*Boost has a year 2038 problem— if the request sleep time is past epoch+2^31 seconds the sleep returns instantly.
-      So we clamp our sleeps here to 10 years and hope that boost is fixed by 2028.*/
-    boost::thread::sleep(boost::get_system_time() + boost::posix_time::milliseconds(n>315576000000LL?315576000000LL:n));
+    this_thread::sleep_for(std::chrono::seconds(n));
 }
 #endif
 


### PR DESCRIPTION
Из-за добавления std::chrono и std::thread получили временную мешанину с boost::thread к примеру. Поэтому на данном этапе прописываем развернутый вариант, как пример: std::thread::hardware_concurrency()