### PR TITLE
Fix CBitcoinAddress::GetKeyID logic

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -352,6 +352,7 @@ bool DecodeBase58Check(const std::string& str, std::vector<unsigned char>& vchRe
             CMalleablePubKey mPubKey;
             mPubKey.setvch(vchData);
             keyID = mPubKey.GetID();
+            return true;
         }
         default: return false;
         }


### PR DESCRIPTION
Fix gcc 7.0 warning (Wimplicit-fallthrough)